### PR TITLE
PCHR-434: Added redirections to 'my documents' and 'my tasks'

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/MyDocuments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/MyDocuments.php
@@ -1,0 +1,15 @@
+<?php
+
+class CRM_Tasksassignments_Page_MyDocuments extends CRM_Core_Page {
+  function run()
+  {
+    if (!CRM_Core_Permission::check('access Tasks and Assignments')) {
+      CRM_Utils_System::redirect('/dashboard#documents');
+    }
+    else {
+      CRM_Utils_System::redirect('/civicrm/tasksassignments/dashboard#/documents');
+    }
+
+    return FALSE;
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/MyTasks.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/MyTasks.php
@@ -1,0 +1,16 @@
+<?php
+
+class CRM_Tasksassignments_Page_MyTasks extends CRM_Core_Page
+{
+  function run()
+  {
+    if (!CRM_Core_Permission::check('access Tasks and Assignments')) {
+      CRM_Utils_System::redirect('/dashboard#tasks');
+    }
+    else {
+      CRM_Utils_System::redirect('/civicrm/tasksassignments/dashboard#/tasks');
+    }
+
+    return FALSE;
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -127,8 +127,8 @@ class CRM_Tasksassignments_Reminder
                 'activitySubject' => isset($activityResult['subject']) ? $activityResult['subject'] : '',
                 'activityDetails' => isset($activityResult['details']) ? $activityResult['details'] : '',
                 'baseUrl' => CIVICRM_UF_BASEURL,
-                'myTasksUrl' => CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#/tasks/my',
-                'myDocumentsUrl' => CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#/documents/my',
+                'myTasksUrl' => CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/my-tasks',
+                'myDocumentsUrl' => CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/my-documents',
             ));
             
             self::_send($contactId, $recipient, $activityName, $templateBodyHTML);

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
@@ -65,4 +65,14 @@
     <page_callback>CRM_Tasksassignments_Page_Settings</page_callback>
     <title>Settings</title>
   </item>
+  <item>
+    <path>civicrm/tasksassignments/my-tasks</path>
+    <page_callback>CRM_Tasksassignments_Page_MyTasks</page_callback>
+    <title>MyTasks</title>
+  </item>
+  <item>
+    <path>civicrm/tasksassignments/my-documents</path>
+    <page_callback>CRM_Tasksassignments_Page_MyDocuments</page_callback>
+    <title>MyDocuments</title>
+  </item>
 </menu>


### PR DESCRIPTION
Changed the links form screenshot below to link to redirection page, that directs user to Tasks and Assignments, or to SSP if they don't have permissions to access TA.
A small change in SSP is required (adding ID's to "Tasks" and "Documents" sections), ~~which I will send in another PR shortly~~ linked below.

<img width="665" alt="screen shot 2016-01-07 at 14 19 44" src="https://cloud.githubusercontent.com/assets/15697510/12197129/5681f41c-b5fc-11e5-9203-c0afe5328876.png">

This PR requires: https://github.com/compucorp/civihr-employee-portal/pull/89