### PR TITLE
PCHR-554: show all keydates for next 7 days in reminder email

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -349,7 +349,7 @@ class CRM_Tasksassignments_Reminder
         $todayKeydatesCount = 0;
         if ($settings['keydates_tab']['value'])
         {
-            $keyDates = CRM_Tasksassignments_KeyDates::get($now, $to, $contactId);
+            $keyDates = CRM_Tasksassignments_KeyDates::get($now, $to);
             foreach ($keyDates as $keyDate)
             {
                 $reminderData['upcoming_keydates'][] = array_merge(


### PR DESCRIPTION
Issue: 
Keydates sections was not displaying all keydates
![t a-keydates-before](https://cloud.githubusercontent.com/assets/7393885/12290490/1c524390-ba08-11e5-9e65-5a0be41e944a.png)



Solution:
Fetch all keydates irrespective of contactID
![t a-keydates-after](https://cloud.githubusercontent.com/assets/7393885/12290497/2480b84e-ba08-11e5-8507-0265a739c6e0.png)
