### PR TITLE
PCHR-858: Add error handling in build process in gulpfile

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/gulpfile.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/gulpfile.js
@@ -19,7 +19,8 @@ gulp.task('sass', function (done) {
 });
 
 gulp.task('requirejs-bundle', function (done) {
-    exec('r.js -o js/build.js', function (_, stdout, stderr) {
+    exec('r.js -o js/build.js', function (err, stdout, stderr) {
+        err && err.code && console.log(stdout);
         done();
     });
 });


### PR DESCRIPTION
This is the same *gulpfile* fix described in [this PR](https://github.com/civicrm/civihr/pull/868) , only applied to the _civihr-tasks-assignments_ repo