### PR TITLE
PCHR-879: Issue with ui-select with AngularJS v1.5

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/documents.html
@@ -22,8 +22,8 @@
                                 <ui-select
                                         multiple
                                         ng-model="filterParams.assignmentType">
-                                    <ui-select-match placeholder="Select assignment...">{{$item.title}}</ui-select-match>
-                                    <ui-select-choices repeat="type.id as type in cache.assignmentType.arr">
+                                    <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
+                                    <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
                                         <div ng-bind-html="type.title | highlight: $select.search"></div>
                                     </ui-select-choices>
                                 </ui-select>
@@ -37,8 +37,8 @@
                                 <ui-select
                                         multiple
                                         ng-model="filterParams.documentStatus">
-                                    <ui-select-match placeholder="Select status...">{{$item.value}}</ui-select-match>
-                                    <ui-select-choices repeat="status.key as status in cache.documentStatus.arr">
+                                    <ui-select-match class="ui-select-match" placeholder="Select status...">{{$item.value}}</ui-select-match>
+                                    <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr">
                                         <div ng-bind-html="status.value | highlight: $select.search"></div>
                                     </ui-select-choices>
                                 </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -18,8 +18,8 @@
                     <ui-select
                             multiple
                             ng-model="filterParams.assignmentType">
-                        <ui-select-match placeholder="Select assignment...">{{$item.title}}</ui-select-match>
-                        <ui-select-choices repeat="type.id as type in cache.assignmentType.arr">
+                        <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
+                        <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
                             <div ng-bind-html="type.title | highlight: $select.search"></div>
                         </ui-select-choices>
                     </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -49,8 +49,8 @@
                             <ui-select
                                     multiple
                                     ng-model="filterParamsHolder.documentStatus">
-                                <ui-select-match placeholder="Select status...">{{$item.value}}</ui-select-match>
-                                <ui-select-choices repeat="status.key as status in cache.documentStatus.arr">
+                                <ui-select-match class="ui-select-match" placeholder="Select status...">{{$item.value}}</ui-select-match>
+                                <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr">
                                     <div ng-bind-html="status.value | highlight: $select.search"></div>
                                 </ui-select-choices>
                             </ui-select>
@@ -118,9 +118,9 @@
                                         <ui-select
                                                 allow-clear
                                                 ng-model="filterParams.contactId">
-                                            <ui-select-match
+                                            <ui-select-match class="ui-select-match"
                                                     placeholder="Search / Filter">{{$select.selected.label}}</ui-select-match>
-                                            <ui-select-choices  repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
+                                            <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
                                                                 refresh-delay="0">
                                                 <div ng-bind="contact.label"></div>
                                                 <small ng-bind="contact.description[0]"></small>
@@ -142,8 +142,8 @@
                                     <ui-select
                                             multiple
                                             ng-model="filterParams.assignmentType">
-                                        <ui-select-match placeholder="Select assignment...">{{$item.title}}</ui-select-match>
-                                        <ui-select-choices repeat="type.id as type in cache.assignmentType.arr">
+                                        <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
+                                        <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
                                             <div ng-bind-html="type.title | highlight: $select.search"></div>
                                         </ui-select-choices>
                                     </ui-select>
@@ -163,9 +163,9 @@
                                     <div class="input-group">
                                         <ui-select
                                                 ng-model="action.selected">
-                                            <ui-select-match
+                                            <ui-select-match class="ui-select-match"
                                                     placeholder="Select action">{{$select.selected.label}}</ui-select-match>
-                                            <ui-select-choices
+                                            <ui-select-choices class="ui-select-choices"
                                                     repeat="actionObj.type as actionObj in actionList">
                                                 <div ng-bind="actionObj.label"></div>
                                             </ui-select-choices>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/key-dates.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/key-dates.html
@@ -71,8 +71,8 @@
                                             <ui-select
                                                     multiple
                                                     ng-model="filterParams.dateType">
-                                                <ui-select-match placeholder="Select date type...">{{$item.value}}</ui-select-match>
-                                                <ui-select-choices repeat="type.key as type in cache.dateType.arr">
+                                                <ui-select-match class="ui-select-match" placeholder="Select date type...">{{$item.value}}</ui-select-match>
+                                                <ui-select-choices class="ui-select-choices" repeat="type.key as type in cache.dateType.arr">
                                                     <div ng-bind-html="type.value | highlight: $select.search"></div>
                                                 </ui-select-choices>
                                             </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -142,10 +142,11 @@
                                         <div class="col-xs-12 col-sm-10">
                                             <div class="input-group">
                                                 <ui-select allow-clear ng-model="filterParams.contactId">
-                                                    <ui-select-match placeholder="Search / Filter">
+                                                    <ui-select-match class="ui-select-match" placeholder="Search / Filter">
                                                         {{$select.selected.label}}
                                                     </ui-select-match>
                                                     <ui-select-choices
+                                                            class="ui-select-choices"
                                                             repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
                                                             refresh-delay="0">
                                                         <div ng-bind="contact.label"></div>
@@ -167,9 +168,9 @@
 
                                         <div class="col-xs-12 col-sm-8">
                                             <ui-select multiple ng-model="filterParams.assignmentType">
-                                                <ui-select-match placeholder="Select assignment...">{{$item.title}}
+                                                <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}
                                                 </ui-select-match>
-                                                <ui-select-choices repeat="type.id as type in cache.assignmentType.arr">
+                                                <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
                                                     <div ng-bind-html="type.title | highlight: $select.search"></div>
                                                 </ui-select-choices>
                                             </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
@@ -21,12 +21,14 @@
                                    ng-change="assignment.client_id=assignment.contact_id"
                                    on-select="cacheContact($item)"
                                    ng-required="true">
-                            <ui-select-match placeholder="Start typing a name or email...">
+                            <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">
                                 {{$select.selected.label}}
                             </ui-select-match>
-                            <ui-select-choices repeat="contact.id as contact in contacts | filter: $select.search"
-                                               refresh="refreshContacts($select.search)"
-                                               refresh-delay="0">
+                            <ui-select-choices
+                                class="ui-select-choices"
+                                repeat="contact.id as contact in contacts | filter: $select.search"
+                                refresh="refreshContacts($select.search)"
+                                refresh-delay="0">
                                 <div ng-bind="contact.label"></div>
                                 <small ng-bind="contact.description[0]"></small>
                             </ui-select-choices>
@@ -45,10 +47,10 @@
                                    ng-change="setData()"
                                    ng-required="true"
                                    search-enabled="false">
-                            <ui-select-match placeholder="- select -">
+                            <ui-select-match class="ui-select-match" placeholder="- select -">
                                 {{$select.selected.title}}
                             </ui-select-match>
-                            <ui-select-choices repeat="value.id as value in cache.assignmentType.arr">
+                            <ui-select-choices class="ui-select-choices" repeat="value.id as value in cache.assignmentType.arr">
                                 <div ng-bind="value.title"></div>
                             </ui-select-choices>
                         </ui-select>
@@ -90,10 +92,11 @@
                                    ng-disabled="!taskList.length"
                                    ng-required="true"
                                    search-enabled="false">
-                            <ui-select-match placeholder="- select -">
+                            <ui-select-match class="ui-select-match" placeholder="- select -">
                                 {{$select.selected.label}}
                             </ui-select-match>
                             <ui-select-choices
+                                    class="ui-select-choices"
                                     repeat="value.id as value in cache.assignmentType.obj[assignment.case_type_id].definition.activitySets">
                                 <div ng-bind="value.label"></div>
                             </ui-select-choices>
@@ -144,10 +147,11 @@
                                 <td colspan="2" ng-if="activity.isAdded">
                                     <div class="ui-select-required">
                                         <ui-select ng-model="activity.activity_type_id" ng-required="!isDisabled && activity.create">
-                                            <ui-select-match placeholder="Select task type">
+                                            <ui-select-match class="ui-select-match" placeholder="Select task type">
                                                 {{$select.selected.value}}
                                             </ui-select-match>
                                             <ui-select-choices
+                                                    class="ui-select-choices"
                                                     repeat="type.key as type in cache.taskType.arr | filter: $select.search">
                                                 <div ng-bind="type.value"></div>
                                             </ui-select-choices>
@@ -161,10 +165,11 @@
                                                ng-disabled="isDisabled || !activity.create"
                                                ng-required="!isDisabled && activity.create"
                                                on-select="cacheContact($item)">
-                                        <ui-select-match placeholder="Start typing a name or email...">
+                                        <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">
                                             {{$select.selected.label}}
                                         </ui-select-match>
                                         <ui-select-choices
+                                                class="ui-select-choices"
                                                 repeat="contact.id as contact in contacts | filter: $select.search"
                                                 refresh="refreshContacts($select.search)"
                                                 refresh-delay="0">
@@ -260,10 +265,11 @@
                                 <td colspan="2" ng-if="activity.isAdded">
                                     <div class="ui-select-required">
                                         <ui-select ng-model="activity.activity_type_id" ng-required="true">
-                                            <ui-select-match placeholder="Select document type">
+                                            <ui-select-match class="ui-select-match" placeholder="Select document type">
                                                 {{$select.selected.value}}
                                             </ui-select-match>
                                             <ui-select-choices
+                                                    class="ui-select-choices"
                                                     repeat="type.key as type in cache.documentType.arr | filter: $select.search">
                                                 <div ng-bind="type.value"></div>
                                             </ui-select-choices>
@@ -277,10 +283,11 @@
                                                ng-disabled="isDisabled || !activity.create"
                                                ng-required="!isDisabled && activity.create"
                                                on-select="cacheContact($item)">
-                                        <ui-select-match placeholder="Start typing a name or email...">
+                                        <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">
                                             {{$select.selected.label}}
                                         </ui-select-match>
                                         <ui-select-choices
+                                                class="ui-select-choices"
                                                 repeat="contact.id as contact in contacts | filter: $select.search"
                                                 refresh="refreshContacts($select.search)"
                                                 refresh-delay="0">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -7,10 +7,11 @@
                         ng-model="document.target_contact_id[0]"
                         on-select="cacheContact($item)"
                         ng-required="true">
-                    <ui-select-match placeholder="Start typing a name or email...">
+                    <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">
                         {{$select.selected.label}}
                     </ui-select-match>
-                    <ui-select-choices repeat="contact.id as contact in contacts | filter: $select.search"
+                    <ui-select-choices class="ui-select-choices"
+                                        repeat="contact.id as contact in contacts | filter: $select.search"
                                        refresh="refreshContacts($select.search)"
                                        refresh-delay="0">
                         <div ng-bind="contact.label"></div>
@@ -34,9 +35,11 @@
                     <ui-select ng-model="document.activity_type_id"
                                ng-required="true">
                         <ui-select-match
+                                class="ui-select-match"
                                 placeholder="Select document type">{{$select.selected.value}}
                         </ui-select-match>
                         <ui-select-choices
+                                class="ui-select-choices"
                                 repeat="type.key as type in cache.documentType.arr | filter: $select.search">
                             <div ng-bind="type.value"></div>
                         </ui-select-choices>
@@ -159,9 +162,11 @@
                             ng-model="document.assignee_contact_id[0]"
                             on-select="cacheContact($item)">
                         <ui-select-match
+                                class="ui-select-match"
                                 placeholder="Start typing a name or email...">{{$select.selected.label}}
                         </ui-select-match>
                         <ui-select-choices
+                                class="ui-select-choices"
                                 repeat="contact.id as contact in contacts | filter: $select.search"
                                 refresh="refreshContacts($select.search)"
                                 refresh-delay="0">
@@ -183,9 +188,11 @@
                             ng-model="document.case_id"
                             on-select="cacheAssignment($item);">
                         <ui-select-match
+                                class="ui-select-match"
                                 placeholder="Enter search term...">{{$select.selected.label}}
                         </ui-select-match>
-                        <ui-select-choices repeat="assignment.id as assignment in assignments"
+                        <ui-select-choices class="ui-select-choices"
+                                           repeat="assignment.id as assignment in assignments"
                                            refresh="refreshAssignments($select.search)"
                                            refresh-delay="0">
                             <div ng-class="assignment.label_class" ng-bind="assignment.label"></div>
@@ -210,10 +217,10 @@
                     <ui-select ng-required="true"
                                allow-clear
                                ng-model="document.status_id">
-                        <ui-select-match placeholder="Set Status">
+                        <ui-select-match class="ui-select-match" placeholder="Set Status">
                             {{$select.selected.value}}
                         </ui-select-match>
-                        <ui-select-choices repeat="status.key as status in cache.documentStatus.arr | filter: $select.search">
+                        <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr | filter: $select.search">
                             <div ng-bind="status.value"></div>
                         </ui-select-choices>
                     </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
@@ -6,10 +6,12 @@
                            ng-model="task.target_contact_id[0]"
                            on-select="cacheContact($item)"
                            ng-required="true">
-                    <ui-select-match placeholder="Select Target Contact">
+                    <ui-select-match class="ui-select-match" placeholder="Select Target Contact">
                         {{$select.selected.label}}
                     </ui-select-match>
-                    <ui-select-choices repeat="contact.id as contact in contacts | filter: $select.search"
+                    <ui-select-choices
+                                       class="ui-select-choices"
+                                       repeat="contact.id as contact in contacts | filter: $select.search"
                                        refresh="refreshContacts($select.search)"
                                        refresh-delay="0">
                         <div ng-bind="contact.label"></div>
@@ -39,10 +41,10 @@
                 <div class="col-xs-12 col-sm-6" ng-show="!data.activity_type_id">
                     <ui-select ng-model="task.activity_type_id"
                             ng-required="true">
-                        <ui-select-match placeholder="Select Task Type">
+                        <ui-select-match class="ui-select-match" placeholder="Select Task Type">
                             {{$select.selected.value}}
                         </ui-select-match>
-                        <ui-select-choices repeat="type.key as type in cache.taskType.arr | filter: $select.search">
+                        <ui-select-choices class="ui-select-choices" repeat="type.key as type in cache.taskType.arr | filter: $select.search">
                             <div ng-bind="type.value"></div>
                         </ui-select-choices>
                     </ui-select>
@@ -113,10 +115,12 @@
                                allow-clear
                                ng-model="task.assignee_contact_id[0]"
                                on-select="cacheContact($item)">
-                        <ui-select-match placeholder="Assignee">
+                        <ui-select-match class="ui-select-match" placeholder="Assignee">
                             {{$select.selected.label}}
                         </ui-select-match>
-                        <ui-select-choices repeat="contact.id as contact in contacts | filter: $select.search"
+                        <ui-select-choices
+                                           class="ui-select-choices"
+                                           repeat="contact.id as contact in contacts | filter: $select.search"
                                            refresh="refreshContacts($select.search)"
                                            refresh-delay="0">
                             <div ng-bind="contact.label"></div>
@@ -138,10 +142,10 @@
                 <div class="col-xs-12 col-sm-5">
                     <ui-select ng-show="showFieldStatus" allow-clear
                                ng-model="task.status_id">
-                        <ui-select-match placeholder="Status">
+                        <ui-select-match class="ui-select-match" placeholder="Status">
                             {{ $select.selected.value }}
                         </ui-select-match>
-                        <ui-select-choices repeat="status.key as status in cache.taskStatus.arr" refresh-delay="0">
+                        <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.taskStatus.arr" refresh-delay="0">
                             <div ng-bind="status.value"></div>
                         </ui-select-choices>
                     </ui-select>
@@ -158,10 +162,12 @@
                     <ui-select allow-clear
                                ng-model="task.case_id"
                                on-select="cacheAssignment($item);">
-                        <ui-select-match placeholder="Assignment">
+                        <ui-select-match class="ui-select-match" placeholder="Assignment">
                             {{$select.selected.label}}
                         </ui-select-match>
-                        <ui-select-choices repeat="assignment.id as assignment in assignments"
+                        <ui-select-choices
+                                           class="ui-select-choices"
+                                           repeat="assignment.id as assignment in assignments"
                                            refresh="refreshAssignments($select.search)"
                                            refresh-delay="0">
                             <div ng-class="assignment.label_class" ng-bind="assignment.label"></div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/taskMigrate.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/taskMigrate.html
@@ -14,8 +14,10 @@
                             on-select="cacheContact($item); getActivities($item.id);"
                             ng-required="true">
                         <ui-select-match
+                                class="ui-select-match"
                                 placeholder="Start typing a name or email...">{{$select.selected.label}}</ui-select-match>
-                        <ui-select-choices  repeat="contact.id as contact in contacts | filter: $select.search"
+                        <ui-select-choices  class="ui-select-choices"
+                                            repeat="contact.id as contact in contacts | filter: $select.search"
                                             refresh="refreshContacts($select.search)"
                                             refresh-delay="0">
                             <div ng-bind="contact.label"></div>
@@ -40,8 +42,10 @@
                             on-select="cacheContact($item)"
                             ng-required="true">
                         <ui-select-match
+                                class="ui-select-match"
                                 placeholder="Start typing a name or email...">{{$select.selected.label}}</ui-select-match>
-                        <ui-select-choices  repeat="contact.id as contact in contacts | filter: $select.search"
+                        <ui-select-choices  class="ui-select-choices"
+                                            repeat="contact.id as contact in contacts | filter: $select.search"
                                             refresh="refreshContacts($select.search)"
                                             refresh-delay="0">
                             <div ng-bind="contact.label"></div>


### PR DESCRIPTION
## Problem
![issue](https://s3-eu-west-1.amazonaws.com/uploads-eu.hipchat.com/124355/3029395/byMFG6CJGn2lYAs/err.png)

The ui.select library is throwing errors now that we have moved to AngularJS v.15 ([PCHR-870](https://github.com/civicrm/civihr/pull/871)). This seems kind of a big (recurrent?) issue for the library which currently still have to be addressed

## Solution
There is a (seemingly working) workaround to this, which consists in applying to the directive tags same-named classes:

```html
<ui-select-match class="ui-select-match"...>
<ui-select-choices class="ui-select-choices" ...>
```

for some reason this works, and so I have gone through every place where the directive is used and implement those classes manually