### PR TITLE
PCHR-637: Add more information to the Assignment lookup select dropdown

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
@@ -166,11 +166,18 @@
                             {{$select.selected.label}}
                         </ui-select-match>
                         <ui-select-choices
-                                           class="ui-select-choices"
-                                           repeat="assignment.id as assignment in assignments"
-                                           refresh="refreshAssignments($select.search)"
-                                           refresh-delay="0">
-                            <div ng-class="assignment.label_class" ng-bind="assignment.label"></div>
+                            class="ui-select-choices"
+                            repeat="assignment.id as assignment in assignments"
+                            refresh="refreshAssignments($select.search)"
+                            refresh-delay="0">
+                            <div>
+                                <div ng-class="assignment.label_class">{{assignment.label}}</div>
+                                <small>
+                                    #{{assignment.id}}: {{assignment.extra.case_status}} (opened: {{assignment.extra.start_date | date:'MMM d, yyyy'}})
+                                    <br>
+                                    {{assignment.extra.case_subject}}
+                                </small>
+                            </div>
                         </ui-select-choices>
                     </ui-select>
                 </div>


### PR DESCRIPTION
Adding more informations (id, status, creation date, subject) to the Assignment lookup select dropdown, to make it work similar to the "File to Case" feature in default CiviCRM

#### Before
![before](https://cloud.githubusercontent.com/assets/6400898/14282763/32d46458-fb40-11e5-8f63-a060a4b38c6b.gif)

#### After
![task-modal](https://cloud.githubusercontent.com/assets/6400898/14282789/4a1df976-fb40-11e5-9524-def396e10378.gif)
