### PR TITLE
PCHR-635: Original assignee is not distinct from the new assignee

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -36,19 +36,75 @@ class CRM_Tasksassignments_Reminder
             self::$_relatedExtensions['appraisals'] = true;
         }
     }
-    
+
+    /**
+     * Gets the contacts starting with the given ids
+     *
+     * It also chains a call to the 'Email' api and puts the value in
+     * the 'email' property
+     *
+     * @param {Array} $contactIds
+     * @return {Array}
+     */
+    private static function _getContactsWithEmail($contactIds) {
+        $contacts = civicrm_api3('Contact', 'get', array(
+            'return' => 'display_name',
+            'id' => array('IN' => $contactIds),
+            'api.Email.getsingle' => array(
+                'contact_id' => "\$value.contact_id",
+                'is_primary' => true,
+                'return' => array('contact_id', 'email')
+            )
+        ))['values'];
+
+        foreach ($contacts as $id => $contact) {
+            $contacts[$id]['email'] = $contact['api.Email.getsingle']['email'];
+            unset($contacts[$id]['api.Email.getsingle']);
+        }
+
+        return $contacts;
+    }
+
+    /**
+     * Returns the links (in <a> tags), names and email of the contacts with given ids
+     * It also populates an array that maps emails to contact ids
+     *
+     * @param {Array} $contactIds
+     * @param {Array} $emailToContactId (by reference) Mapping between emails and contact ids
+     * @return {Array}
+     */
+    private static function _getActivityContactsDetails($contactIds, &$emailToContactId) {
+        $details = array('links' => array(), 'names' => array(), 'emails' => array());
+        $contacts = self::_getContactsWithEmail($contactIds);
+
+        foreach ($contacts as $id => $contact) {
+            $url = CIVICRM_UF_BASEURL . '/civicrm/contact/view?reset=1&cid=' . $id;
+            $details['links'][] = '<a href="' . $url . '" style="color:#42b0cb;font-weight:normal;text-decoration:underline;">' . $contact['display_name'] . '</a>';
+            $details['names'][] = $contact['display_name'];
+
+            if ($contact['email']) {
+                $details['emails'][] = $contact['email'];
+                $emailToContactId[$contact['email']] = $id;
+            }
+        }
+
+        return $details;
+    }
+
+
     public static function sendReminder($activityId, $notes = null, $isReminder = false, $previousAssigneeId = null, $isDelete = false)
     {
         self::_setActivityOptions();
-        
-        $activityContact = array(
-            1 => array(), // assignees
-            2 => array(), // source
-            3 => array(), // targets
-        );
-        
+
+        $contactTypeToLabel = array(1 => 'assignees', 2 => 'source', 3 => 'targets');
+        $activityContacts = array();
+
+        foreach ($contactTypeToLabel as $type) {
+            $activityContacts[$type] = array();
+        }
+
         $emailToContactId = array();
-        
+
         $activityResult = civicrm_api3('Activity', 'get', array(
           'sequential' => 1,
           'activity_id' => $activityId,
@@ -56,69 +112,44 @@ class CRM_Tasksassignments_Reminder
           'is_deleted' => 0,
         ));
         $activityResult = CRM_Utils_Array::first($activityResult['values']);
-        
+
         $activityContactResult = civicrm_api3('ActivityContact', 'get', array(
           'sequential' => 1,
           'activity_id' => $activityId,
         ));
-        
+
         foreach ($activityContactResult['values'] as $value)
         {
-            $activityContact[$value['record_type_id']]['ids'][] = $value['contact_id'];
+            $type = $contactTypeToLabel[$value['record_type_id']];
+            $activityContacts[$type]['ids'][] = $value['contact_id'];
         }
 
         if($previousAssigneeId !== null)
         {
-            $activityContact[1]['ids'][] = $previousAssigneeId;
+            $activityContacts['assignees']['ids'][] = $previousAssigneeId;
         }
-        
-        foreach ($activityContact as $key => $value)
+
+        foreach ($activityContacts as $type => $contacts)
         {
             if (empty($value))
             {
                 continue;
             }
-            
-            $links = array();
-            $names = array();
-            $emails = array();
-            
-            $contactResult = civicrm_api3('Contact', 'get', array(
-              'return' => 'display_name',
-              'id' => array('IN' => $value['ids']),
-            ));
-            
-            $emailResult = civicrm_api3('Email', 'get', array(
-              'return' => 'contact_id,email',
-              'contact_id' => array('IN' => $value['ids']),
-              'is_primary' => 1,
-            ));
-            
-            foreach ($contactResult['values'] as $contactKey => $contactValue)
-            {
-                $url = CIVICRM_UF_BASEURL . '/civicrm/contact/view?reset=1&cid=' . $contactKey;
-                $links[] = '<a href="' . $url . '" style="color:#42b0cb;font-weight:normal;text-decoration:underline;">' . $contactValue['display_name'] . '</a>';
-                $names[] = $contactValue['display_name'];
-            }
-            
-            foreach ($emailResult['values'] as $contactValue)
-            {
-                $emails[] = $contactValue['email'];
-                $emailToContactId[$contactValue['email']] = $contactValue['contact_id'];
-            }
-            
-            $activityContact[$key]['links'] = $links;
-            $activityContact[$key]['names'] = $names;
-            $activityContact[$key]['emails'] = $emails;
+
+            $details = self::_getActivityContactsDetails($contacts['ids'], $emailToContactId);
+
+            $activityContacts[$type]['links'] = $details['links'];
+            $activityContacts[$type]['names'] = $details['names'];
+            $activityContacts[$type]['emails'] = $details['emails'];
         }
-        
+
         $template = &CRM_Core_Smarty::singleton();
-        
-        $recipients = array_unique(array_merge($activityContact[1]['emails'], $activityContact[2]['emails']));
+
+        $recipients = array_unique(array_merge($activityContacts['assignees']['emails'], $activityContacts['source']['emails']));
         foreach ($recipients as $recipient)
         {
             $contactId = $emailToContactId[$recipient];
-            $activityName = implode(', ', $activityContact[3]['names']) . ' - ' . self::$_activityOptions['type'][$activityResult['activity_type_id']];
+            $activityName = implode(', ', $activityContacts['targets']['names']) . ' - ' . self::$_activityOptions['type'][$activityResult['activity_type_id']];
             $templateBodyHTML = $template->fetchWith('CRM/Tasksassignments/Reminder/Reminder.tpl', array(
                 'isReminder' => $isReminder,
                 'isDelete' => $isDelete,
@@ -126,8 +157,8 @@ class CRM_Tasksassignments_Reminder
                 'activityUrl' => CIVICRM_UF_BASEURL . '/civicrm/activity/view?action=view&reset=1&id=' . $activityId . '&cid=&context=activity&searchContext=activity',
                 'activityName' => $activityName,
                 'activityType' => self::$_activityOptions['type'][$activityResult['activity_type_id']],
-                'activityTargets' => implode(', ', $activityContact[3]['links']),
-                'activityAssignee' => implode(', ', $activityContact[1]['links']),
+                'activityTargets' => implode(', ', $activityContacts['targets']['links']),
+                'activityAssignee' => implode(', ', $activityContacts['assignees']['links']),
                 'activityStatus' => self::$_activityOptions['status'][$activityResult['status_id']],
                 'activityDue' => substr($activityResult['activity_date_time'], 0, 10),
                 'activitySubject' => isset($activityResult['subject']) ? $activityResult['subject'] : '',

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -43,8 +43,8 @@ class CRM_Tasksassignments_Reminder
      * It also chains a call to the 'Email' api and puts the value in
      * the 'email' property
      *
-     * @param {Array} $contactIds
-     * @return {Array}
+     * @param array $contactIds
+     * @return array
      */
     private static function _getContactsWithEmail($contactIds) {
         $contacts = civicrm_api3('Contact', 'get', array(
@@ -69,9 +69,9 @@ class CRM_Tasksassignments_Reminder
      * Returns the links (in <a> tags), names and email of the contacts with given ids
      * It also populates an array that maps emails to contact ids
      *
-     * @param {Array} $contactIds
-     * @param {Array} $emailToContactId (by reference) Mapping between emails and contact ids
-     * @return {Array}
+     * @param array $contactIds
+     * @param array $emailToContactId (by reference) Mapping between emails and contact ids
+     * @return array
      */
     private static function _getActivityContactsDetails($contactIds, &$emailToContactId) {
         $details = array('ids' => array(), 'links' => array(), 'names' => array(), 'emails' => array());
@@ -97,9 +97,9 @@ class CRM_Tasksassignments_Reminder
      * Extracts the previous assignee from the list of the activity assignees
      * Once the assignee has been found, it is removed from the original list
      *
-     * @param {Array} $assignees
-     * @param {id} $previousAssigneeId
-     * @return {Array} consists of id, link, email and name of the previous assignee
+     * @param array $assignees
+     * @param int $previousAssigneeId
+     * @return array consists of id, link, email and name of the previous assignee
      */
     private static function _extractPreviousAssignee(&$assignees, $previousAssigneeId) {
         $index = null;
@@ -134,9 +134,9 @@ class CRM_Tasksassignments_Reminder
      * Gets the full list of the recipients of the reminder email
      * Makes sure there are no duplicates or no empty emails in the list
      *
-     * @param {Array} $activityContacts
-     * @param {Array} $previousAssignee
-     * @return {Array}
+     * @param array $activityContacts
+     * @param array $previousAssignee
+     * @return array
      */
     private static function _reminderRecipients($activityContacts, $previousAssignee) {
         return array_filter(array_unique(array_merge(

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Reminder.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Reminder.tpl
@@ -18,8 +18,20 @@
 {/if}
 {if $activityAssignee}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Assignee:</td>
+        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+            {if $previousAssignee}
+                New Assignee:
+            {else}
+                Assignee:
+            {/if}
+        </td>
         <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityAssignee}</td>
+    </tr>
+{/if}
+{if $previousAssignee}
+    <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+        <td width="25%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Original Assignee:</td>
+        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$previousAssignee}</td>
     </tr>
 {/if}
 {if $activityType}


### PR DESCRIPTION
## Problem
When a task is assigned from a person to another, the old assignee is listed in the "Assignee" list alongside the new one, making harder to tell which one is which

<img width="796" alt="before" src="https://cloud.githubusercontent.com/assets/6400898/14380506/180f3138-fd80-11e5-9593-cbfab7a4f437.png">

## Solution
The previous assignee is now displayed separately from the new one

<img width="637" alt="after" src="https://cloud.githubusercontent.com/assets/6400898/14380509/1be9e51e-fd80-11e5-9552-46f844e74546.png">

### Code refactoring
Also the `sendReminder` static method has been refactored (the focus was kept still on the scope of the ticket, so no parts of the code unrelated to the issue were changed) into smaller methods.

One noteworthy change was how the activity contact's emails were fetched. Before it was done with two api calls:
```php
$contactResult = civicrm_api3('Contact', 'get', array(
  'return' => 'display_name',
  'id' => array('IN' => $value['ids']),
));

$emailResult = civicrm_api3('Email', 'get', array(
  'return' => 'contact_id,email',
  'contact_id' => array('IN' => $value['ids']),
  'is_primary' => 1,
));
```
After the refactoring, the same result is achieved with one api call only, by chaining the two calls together:
```php
$contacts = civicrm_api3('Contact', 'get', array(
    'return' => 'display_name',
    'id' => array('IN' => $contactIds),
    'api.Email.getsingle' => array(
        'contact_id' => "\$value.contact_id",
        'is_primary' => true,
        'return' => array('contact_id', 'email')
    )
))['values'];
```
