### PR TITLE
PCHR-901: Task and Documents tab on Contact page are stuck in a loading loop

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/modules/run.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/modules/run.js
@@ -1,12 +1,10 @@
 define([
     'common/angular',
+    'common/modules/xeditable-civi',
     'tasks-assignments/vendor/angular-bootstrap-calendar',
     'tasks-assignments/vendor/angular-checklist-model',
     'tasks-assignments/vendor/angular-router',
     'tasks-assignments/vendor/angular-select',
-    'tasks-assignments/vendor/angular-xeditable',
-    'tasks-assignments/vendor/angular-xeditable-civi',
-    'tasks-assignments/vendor/text-angular',
     'tasks-assignments/modules/config',
     'tasks-assignments/modules/settings',
     'common/modules/routers/compu-ui-router',

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Documents.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Documents.tpl
@@ -2,7 +2,7 @@
 {assign var="prefix" value="ct-" }
 
 <div id="{$module}" ng-controller="MainCtrl" ct-spinner ct-spinner-show>
-    <div class="container fade-in" ng-view>
+    <div class="container fade-in" ui-view>
     </div>
 </div>
 {literal}

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Tasks.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Tasks.tpl
@@ -2,7 +2,7 @@
 {assign var="prefix" value="ct-" }
 
 <div id="{$module}" ng-controller="MainCtrl" ct-spinner ct-spinner-show>
-    <div class="container fade-in" ng-view>
+    <div class="container fade-in" ui-view>
     </div>
 </div>
 {literal}


### PR DESCRIPTION
### Problem
The "Tasks" and "Documents" tabs in the Contact page weren't loading. The former appeared to be stuck in a loading loop, the latter just didn't show anything

![before](https://cloud.githubusercontent.com/assets/6400898/14388680/7f76369e-fdaf-11e5-91e0-bde513fa8ad5.gif)

### Solution
There were two issues that caused the bug:
1. We moved the t&a app from `ngRoute` to `ui.router` ([commit](https://github.com/compucorp/civihr-tasks-assignments/commit/770dea1112a177cf99599c21929af25a12fa17fd)) but forgot to change the `ng-view` directive into `ui-view` in the documents and tasks templates
2. The `textAngular` angular module was causing problems, which were fixed by using the version store in the `common/` dependencies and by [this PR](https://github.com/civicrm/civihr/pull/890)

![after](https://cloud.githubusercontent.com/assets/6400898/14388723/a94e2c1a-fdaf-11e5-92b5-a0ff50f3769b.gif)
