### PR TITLE
PCHR-637: Fix 'add to assignment' in documents modal.

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -195,7 +195,14 @@
                                            repeat="assignment.id as assignment in assignments"
                                            refresh="refreshAssignments($select.search)"
                                            refresh-delay="0">
-                            <div ng-class="assignment.label_class" ng-bind="assignment.label"></div>
+                            <div>
+                                <div ng-class="assignment.label_class">{{assignment.label}}</div>
+                                <small>
+                                    #{{assignment.id}}: {{assignment.extra.case_status}} (opened: {{assignment.extra.start_date | date:'MMM d, yyyy'}})
+                                    <br>
+                                    {{assignment.extra.case_subject}}
+                                </small>
+                            </div>
                         </ui-select-choices>
                     </ui-select>
                 </div>


### PR DESCRIPTION
Addressing the same issue as #35, but this time for 'add new document' modal.

## Description
Adding more informations (id, status, creation date, subject) to the Assignment lookup select dropdown, to make it work similar to the "File to Case" feature in default CiviCRM

### Before
![drop_before](https://cloud.githubusercontent.com/assets/5514826/14389445/f31385ae-fdb2-11e5-9326-8f48a3f6a262.png)

### After
![dropdown_after](https://cloud.githubusercontent.com/assets/5514826/14389451/f8079a50-fdb2-11e5-82e1-48248a256f56.png)