### PR TITLE
PCHR-573: Assignment menu links need to be cleaned up

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -448,6 +448,26 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
 
     return true;
   }
+
+  /**
+   * Disables the Case menu items if Tasks&Assignments is enabled
+   *
+   * @return {boolean}
+   */
+  public function upgrade_1017()
+  {
+    $isEnabled = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'uk.co.compucorp.civicrm.tasksassignments', 'is_active', 'full_name');
+    $isCaseEnabled = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.hrcase', 'is_active', 'full_name');
+
+    if ($isEnabled && $isCaseEnabled) {
+      CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET is_active=0 WHERE name = 'Cases' AND parent_id IS NULL");
+      CRM_Core_BAO_Navigation::resetNavigation();
+
+      return true;
+    }
+
+    return false;
+  }
     
     public function uninstall()
     {

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -46,11 +46,10 @@ function tasksassignments_civicrm_uninstall() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
  */
 function tasksassignments_civicrm_enable() {
-  
-  $sql = "UPDATE civicrm_navigation SET is_active=1 WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')";
-  CRM_Core_DAO::executeQuery($sql);
+  _toggleMenuItems();
+  if (_isCaseEnabled()) { _toggleCaseMenuItems(false); }
+
   CRM_Core_BAO_Navigation::resetNavigation();
-  
   _tasksassignments_civix_civicrm_enable();
 }
 
@@ -60,11 +59,10 @@ function tasksassignments_civicrm_enable() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
  */
 function tasksassignments_civicrm_disable() {
-  
-  $sql = "UPDATE civicrm_navigation SET is_active=0 WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')";
-  CRM_Core_DAO::executeQuery($sql);
+  _toggleMenuItems(false);
+  if (_isCaseEnabled()) { _toggleCaseMenuItems(true); }
+
   CRM_Core_BAO_Navigation::resetNavigation();
-  
   _tasksassignments_civix_civicrm_disable();
 }
 
@@ -204,4 +202,39 @@ function tasksassignments_civicrm_permission(&$permissions) {
     'delete Tasks and Documents' => $prefix . ts('delete Tasks and Documents'),
     'access Tasks and Assignments' => $prefix . ts('access Tasks and Assignments'),
   );
+}
+
+/**
+ * Checks if the Case extension is enabled
+ *
+ * @return {boolean}
+ */
+function _isCaseEnabled() {
+  return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.hrcase', 'is_active', 'full_name');
+}
+
+/**
+ * Sets the is_state flag of its own menu items
+ *
+ * @param boolean $activate
+ * @return void
+ */
+function _toggleMenuItems($activate = true) {
+  $is_active = $activate ? 1 : 0;
+  $sql = "UPDATE civicrm_navigation SET is_active=$is_active WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')";
+
+  CRM_Core_DAO::executeQuery($sql);
+}
+
+/**
+ * Sets the is_state flag of the Case extension menu items
+ *
+ * @param boolean $activate
+ * @return void
+ */
+function _toggleCaseMenuItems($activate = true) {
+  $is_active = $activate ? 1 : 0;
+  $sql = "UPDATE civicrm_navigation SET is_active=$is_active WHERE name = 'Cases' AND parent_id IS NULL";
+
+  CRM_Core_DAO::executeQuery($sql);
 }


### PR DESCRIPTION
We need to disable the menu items of the Case extension (`org.civicrm.hrcase`) when Tasks&Assignments is enabled.
To be sure this change is retroactive, an upgrader has been written as well