### PR TITLE
PCHR-772: Swap lookup directive for normal select dropdown

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -10082,6 +10082,75 @@ fieldset[disabled]
 #civitasks .editable-error, #cividocuments .editable-error {
   display: none;
 }
+#civitasks .crm_custom-select, #cividocuments .crm_custom-select {
+  background: #ffffff;
+  display: inline-block;
+  position: relative;
+}
+#civitasks .crm_custom-select > select, #cividocuments .crm_custom-select > select {
+  background: transparent;
+  padding-right: 44px;
+  position: relative;
+  width: 100%;
+  z-index: 2;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-border-radius: 0px;
+}
+#civitasks .crm_custom-select > select::-ms-expand, #cividocuments .crm_custom-select > select::-ms-expand {
+  display: none;
+}
+#civitasks .crm_custom-select > select:disabled + .crm_custom-select__arrow, #cividocuments .crm_custom-select > select:disabled + .crm_custom-select__arrow {
+  z-index: 2;
+}
+#civitasks .crm_custom-select > select:focus + .crm_custom-select__arrow, #cividocuments .crm_custom-select > select:focus + .crm_custom-select__arrow {
+  border-color: #66afe9;
+}
+.ie9 #civitasks .crm_custom-select > select, .ie9 #cividocuments .crm_custom-select > select {
+  padding-right: 10px;
+}
+.ie9 #civitasks .crm_custom-select .crm_custom-select__arrow, .ie9 #cividocuments .crm_custom-select .crm_custom-select__arrow {
+  display: none;
+}
+#civitasks .crm_custom-select--full, #cividocuments .crm_custom-select--full {
+  display: block;
+  width: auto;
+}
+#civitasks .crm_custom-select--transparent, #cividocuments .crm_custom-select--transparent {
+  background: transparent;
+}
+#civitasks .crm_custom-select--transparent option, #cividocuments .crm_custom-select--transparent option {
+  background: #ffffff;
+}
+#civitasks .crm_custom-select__arrow, #cividocuments .crm_custom-select__arrow {
+  border-left: 1px solid #727e8a;
+  bottom: 0;
+  display: inline-block;
+  line-height: 31px;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 0;
+  width: 32px;
+  z-index: 1;
+}
+#civitasks .crm_custom-select__arrow:before, #cividocuments .crm_custom-select__arrow:before {
+  content: '\f0d7';
+  color: #727e8a;
+  font-family: "FontAwesome";
+  font-style: normal;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+}
+#civitasks .has-error .crm_custom-select__arrow, #cividocuments .has-error .crm_custom-select__arrow {
+  border-color: #f08290 !important;
+}
+#civitasks .has-feedback > .crm_custom-select > select, #cividocuments .has-feedback > .crm_custom-select > select {
+  padding-right: 54px;
+}
+#civitasks .has-feedback > .crm_custom-select + .form-control-feedback, #cividocuments .has-feedback > .crm_custom-select + .form-control-feedback {
+  right: 27px !important;
+}
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   #civitasks .ct-sidebar-main, #cividocuments .ct-sidebar-main {
     margin-left: 0;

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks.scss
@@ -128,6 +128,7 @@
   @import "civitasks/partials/spinner";
   @import "civitasks/partials/tables";
   @import "civitasks/partials/editable";
+  @import "civitasks/partials/custom-select";
 
   @import "civitasks/modules/ie";
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_custom-select.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_custom-select.scss
@@ -1,0 +1,107 @@
+$customselect-background:             #ffffff;
+$customselect-caret-width:            32;
+$customselect-padding-right:          $customselect-caret-width + 12;
+$customselect-feedback-padding-right: $customselect-padding-right + 10;
+
+.crm_custom-select {
+    background: $customselect-background;
+    display: inline-block;
+    position: relative;
+
+    > select {
+        background: transparent;
+        padding-right: #{$customselect-padding-right}px;
+        position: relative;
+        width: 100%;
+        z-index: 2;
+
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        -webkit-border-radius: 0px;
+
+        &::-ms-expand {
+            display: none;
+        }
+
+        &:disabled {
+
+            + .crm_custom-select__arrow {
+                z-index: 2;
+            }
+        }
+
+        &:focus {
+
+            + .crm_custom-select__arrow {
+                border-color: $input-border-focus;
+            }
+        }
+    }
+
+    .ie9 & {
+
+        > select {
+            padding-right: 10px;
+        }
+
+        .crm_custom-select__arrow {
+            display: none;
+        }
+    }
+}
+
+.crm_custom-select--full {
+    display: block;
+    width: auto;
+}
+
+.crm_custom-select--transparent {
+    background: transparent;
+
+    option {
+        background: $customselect-background;
+    }
+}
+
+.crm_custom-select__arrow {
+    border-left: 1px solid $input-border;
+    bottom: 0;
+    display: inline-block;
+    line-height: #{$customselect-caret-width - 1}px;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    top: 0;
+    width: #{$customselect-caret-width}px;
+    z-index: 1;
+
+    &:before {
+        content: '\f0d7';
+        color: $text-color;
+        font-family: "FontAwesome";
+        font-style: normal;
+        text-rendering: auto;
+        -webkit-font-smoothing: antialiased;
+    }
+}
+
+.has-error {
+
+    .crm_custom-select__arrow {
+        border-color: $brand-danger !important;
+    }
+}
+
+.has-feedback {
+
+    > .crm_custom-select {
+
+        > select {
+            padding-right: #{$customselect-feedback-padding-right}px;
+        }
+
+        + .form-control-feedback {
+            right: #{$customselect-caret-width - 5}px !important;
+        }
+    }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
@@ -43,17 +43,17 @@
                     <label class="col-xs-12 col-sm-3 control-label">Assignment Type:</label>
 
                     <div class="col-xs-12 col-sm-5">
-                        <ui-select ng-model="assignment.case_type_id"
-                                   ng-change="setData()"
-                                   ng-required="true"
-                                   search-enabled="false">
-                            <ui-select-match class="ui-select-match" placeholder="- select -">
-                                {{$select.selected.title}}
-                            </ui-select-match>
-                            <ui-select-choices class="ui-select-choices" repeat="value.id as value in cache.assignmentType.arr">
-                                <div ng-bind="value.title"></div>
-                            </ui-select-choices>
-                        </ui-select>
+                        <div class="crm_custom-select crm_custom-select--full">
+                            <select
+                                ng-required
+                                class="form-control"
+                                ng-change="setData()"
+                                ng-model="assignment.case_type_id"
+                                ng-options="value.id as value.title for value in cache.assignmentType.arr">
+                                <option value="">- select -</option>
+                            </select>
+                            <span class="crm_custom-select__arrow"></span>
+                        </div>
                     </div>
 
                     <label class="col-xs-12 col-sm-1 control-label no-wrap" for="{{prefix}}assignment-due">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -32,18 +32,16 @@
             <!-- Document Type -->
             <div class="row">
                 <div class="col-xs-12">
-                    <ui-select ng-model="document.activity_type_id"
-                               ng-required="true">
-                        <ui-select-match
-                                class="ui-select-match"
-                                placeholder="Select document type">{{$select.selected.value}}
-                        </ui-select-match>
-                        <ui-select-choices
-                                class="ui-select-choices"
-                                repeat="type.key as type in cache.documentType.arr | filter: $select.search">
-                            <div ng-bind="type.value"></div>
-                        </ui-select-choices>
-                    </ui-select>
+                    <div class="crm_custom-select crm_custom-select--full">
+                        <select
+                            ng-required
+                            class="form-control"
+                            ng-model="document.activity_type_id"
+                            ng-options="type.key as type.value for type in cache.documentType.arr">
+                            <option value="">Select document type</option>
+                        </select>
+                        <span class="crm_custom-select__arrow"></span>
+                    </div>
                 </div>
             </div>
             <!-- Dates -->
@@ -219,15 +217,16 @@
                 </label>
 
                 <div class="col-xs-12 col-sm-6" ng-show="showStatusField">
-                    <ui-select allow-clear
-                               ng-model="document.status_id">
-                        <ui-select-match class="ui-select-match" placeholder="Set Status">
-                            {{$select.selected.value}}
-                        </ui-select-match>
-                        <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr | filter: $select.search">
-                            <div ng-bind="status.value"></div>
-                        </ui-select-choices>
-                    </ui-select>
+                    <div class="crm_custom-select crm_custom-select--full">
+                        <select
+                            ng-required
+                            class="form-control"
+                            ng-model="document.status_id"
+                            ng-options="status.key as status.value for status in cache.documentStatus.arr">
+                            <option value="">Set Status</option>
+                        </select>
+                        <span class="crm_custom-select__arrow"></span>
+                    </div>
                 </div>
                 <label class="col-xs-12 control-label">Details</label>
                 <div class="col-xs-12">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
@@ -40,15 +40,16 @@
                     </div>
                 </div>
                 <div class="col-xs-12 col-sm-6" ng-show="!data.activity_type_id">
-                    <ui-select ng-model="task.activity_type_id"
-                            ng-required="true">
-                        <ui-select-match class="ui-select-match" placeholder="Select Task Type">
-                            {{$select.selected.value}}
-                        </ui-select-match>
-                        <ui-select-choices class="ui-select-choices" repeat="type.key as type in cache.taskType.arr | filter: $select.search">
-                            <div ng-bind="type.value"></div>
-                        </ui-select-choices>
-                    </ui-select>
+                    <div class="crm_custom-select crm_custom-select--full">
+                        <select
+                            ng-required
+                            class="form-control"
+                            ng-model="task.activity_type_id"
+                            ng-options="type.key as type.value for type in cache.taskType.arr">
+                            <option value="">Select Task Type</option>
+                        </select>
+                        <span class="crm_custom-select__arrow"></span>
+                    </div>
                 </div>
                 <label class="control-label no-gutter col-sm-2" for="{{prefix}}task-due">
                     <span class="pull-right">Due Date:</span>
@@ -141,14 +142,16 @@
                     </span>
                 </div>
                 <div class="col-xs-12 col-sm-5" ng-show="task.status_id || showFieldStatus">
-                    <ui-select allow-clear ng-model="task.status_id">
-                        <ui-select-match class="ui-select-match" placeholder="Status">
-                            {{ $select.selected.value }}
-                        </ui-select-match>
-                        <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.taskStatus.arr" refresh-delay="0">
-                            <div ng-bind="status.value"></div>
-                        </ui-select-choices>
-                    </ui-select>
+                    <div class="crm_custom-select crm_custom-select--full">
+                        <select
+                            ng-required
+                            class="form-control"
+                            ng-model="task.status_id"
+                            ng-options="status.key as status.value for status in cache.taskStatus.arr">
+                            <option value="">Status</option>
+                        </select>
+                        <span class="crm_custom-select__arrow"></span>
+                    </div>
                 </div>
                 <!-- Assignment -->
                 <div class="col-xs-12 col-sm-7" ng-show="!task.case_id && !showFieldAssignment">


### PR DESCRIPTION
As a quickfix before the ui-select dropdown is properly customized, in case where the directive is used just as a standard select dropdown (that is, single value without the search/filter functionality enabled), then the directive is removed and a normal custom-style select element (`.crm_custom-select`) is used

Since the T&A extension is still not using the common style and since .crm_custom-select is defined in there, then as a quick fix the `.crm_custom-select` is redefined as a local partial in the extension (ugly fix, for we can't wait until we make the full swap to using the common style)

#### Before

<img width="514" alt="before-task" src="https://cloud.githubusercontent.com/assets/6400898/14645392/c723a180-0655-11e6-98af-d3a309cd6f29.png">
<img width="819" alt="before-assignment" src="https://cloud.githubusercontent.com/assets/6400898/14645394/c7286800-0655-11e6-9785-27a6ef356494.png">
<img width="517" alt="before-document" src="https://cloud.githubusercontent.com/assets/6400898/14645393/c726d134-0655-11e6-8230-155f72867bb5.png">


#### After
<img width="520" alt="after-task" src="https://cloud.githubusercontent.com/assets/6400898/14645404/cc251b00-0655-11e6-8707-1049879c9d92.png">
<img width="819" alt="after-assignment" src="https://cloud.githubusercontent.com/assets/6400898/14645403/cc233524-0655-11e6-9b85-338ee10e0d3b.png">
<img width="513" alt="after-document" src="https://cloud.githubusercontent.com/assets/6400898/14645402/cc217c84-0655-11e6-992e-cace5175c735.png">
