### PR TITLE
PCHR-853: Increase z-index of ui-select dropdown list

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -7291,6 +7291,7 @@ fieldset[disabled]
   max-height: 200px;
   overflow-x: hidden;
   margin-top: -1px;
+  z-index: 1500;
 }
 #civitasks body > .ui-select-bootstrap.open, #cividocuments body > .ui-select-bootstrap.open {
   z-index: 1000;

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/modules/_select.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/modules/_select.scss
@@ -126,6 +126,7 @@ body > .select2-container.open {
   max-height: 200px;
   overflow-x: hidden;
   margin-top: -1px;
+  z-index: 1500;
 }
 
 body > .ui-select-bootstrap.open {


### PR DESCRIPTION
The `ui-select` directive can be used as a [angular-xeditable](https://vitalets.github.io/angular-xeditable/) field, meaning that the `z-index` of all the different elements ("follow link" links, action buttons, dropdown list, etc) can be in conflict with one another.

![before](https://cloud.githubusercontent.com/assets/6400898/14706080/ee4d1d32-07bc-11e6-8561-fc425edc3f37.gif)

The dropdown list however should always be on top of all the other elements, so its `z-index` has been increased

![after](https://cloud.githubusercontent.com/assets/6400898/14706082/f4f0bc16-07bc-11e6-94f7-ecf18ad7572b.gif)
