### PR TITLE
PCHR-1022: Adding .editorconfig file to repo

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/.editorconfig
+++ b/uk.co.compucorp.civicrm.tasksassignments/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
Adding a [.editorconfig](http://editorconfig.org/) file to standardize coding style for all the project's developers/contributors