### PR TITLE
PCHR-1075: Fix permissions

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -1,7 +1,7 @@
 <?php
 
 class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
-{    
+{
     public function install() {
 
       // $this->executeCustomDataFile('xml/customdata.xml');
@@ -14,13 +14,13 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
             $this->{$methodName}();
           }
       }
-      
+
     $this->setComponentStatuses(array(
       'CiviTask' => true,
       'CiviDocument' => true,
     ));
     }
-    
+
   public function enable() {
     $this->setComponentStatuses(array(
       'CiviTask' => true,
@@ -28,14 +28,14 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     ));
     return TRUE;
   }
-  
+
   public function disable() {
     $this->setComponentStatuses(array(
       'CiviTask' => false,
       'CiviDocument' => false,
     ));
   }
-    
+
   /**
    * Set components as enabled or disabled. Leave any other
    * components unmodified.
@@ -100,29 +100,29 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     }
 
     public function upgrade_0002() {
-          // Add Tasks and Assignments to the Top Navigation menu
-          CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name = 'tasksassignments' and parent_id IS NULL");
+      // Add Tasks and Assignments to the Top Navigation menu
+      CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name = 'tasksassignments' and parent_id IS NULL");
 
-          $weight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'weight', 'name');
-          //$contactNavId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'id', 'name');
-          $importJobNavigation = new CRM_Core_DAO_Navigation();
-          $params = array (
-              'domain_id'  => CRM_Core_Config::domainID(),
-              'label'      => ts('Tasks and Assignments'),
-              'name'       => 'tasksassignments',
-              'url'        => 'civicrm/tasksassignments/dashboard#/tasks',
-              'parent_id'  => null,
-              'weight'     => $weight+1,
-              //'permission' => 'access Tasksassignments',
-              'separator'  => 1,
-              'is_active'  => 1
-          );
-          $importJobNavigation->copyValues($params);
-          $importJobNavigation->save();
+      $weight = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'weight', 'name');
+      //$contactNavId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Contacts', 'id', 'name');
+      $importJobNavigation = new CRM_Core_DAO_Navigation();
+      $params = array (
+        'domain_id'  => CRM_Core_Config::domainID(),
+        'label'      => ts('Tasks and Assignments'),
+        'name'       => 'tasksassignments',
+        'url'        => 'civicrm/tasksassignments/dashboard#/tasks',
+        'parent_id'  => null,
+        'weight'     => $weight+1,
+        'permission' => 'access Tasks and Assignments',
+        'separator'  => 1,
+        'is_active'  => 1
+      );
+      $importJobNavigation->copyValues($params);
+      $importJobNavigation->save();
 
-          CRM_Core_BAO_Navigation::resetNavigation();
+      CRM_Core_BAO_Navigation::resetNavigation();
 
-          return TRUE;
+      return TRUE;
     }
 
     public function upgrade_0003() {
@@ -179,10 +179,10 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
                 'Block work email ID',
             ),
         ));
-        
+
         return TRUE;
     }
-    
+
     /*
      * Install Documents statuses
      */
@@ -216,7 +216,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
 
         return TRUE;
     }
-    
+
     /*
      * Install Tasks Assignments custom settings.
      */
@@ -266,21 +266,21 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
 
         return TRUE;
     }
-    
+
     public function upgrade_0008()
     {
         $this->executeCustomDataFile('xml/activity_custom_fields.xml');
 
         return TRUE;
     }
-    
+
     public function upgrade_0009()
     {
         $this->executeCustomDataFile('xml/probation.xml');
-        
+
         return TRUE;
     }
-    
+
     /*
      * Enable CiviTask and CiviDocument components.
      */
@@ -288,10 +288,10 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     {
         CRM_Core_BAO_ConfigSetting::enableComponent('CiviTask');
         CRM_Core_BAO_ConfigSetting::enableComponent('CiviDocument');
-        
+
         return TRUE;
     }*/
-    
+
     /*
      * Install Document Types
      */
@@ -309,10 +309,10 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
                 'Exiting document 3',
             ),
         ));
-        
+
         return TRUE;
     }
-    
+
     /*
      * Set up Daily Reminder job
      */
@@ -335,10 +335,10 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
             $dao->is_active = 0;
             $dao->save();
         }
-        
+
         return TRUE;
     }
-    
+
     /*
      * Add Settings page to Tasks and Assignments top menu
      */
@@ -351,7 +351,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
         {
             $taNavigation->url = '';
             $taNavigation->save();
-            
+
             $submenu = array(
                 array(
                     'label' => ts('Dashboard'),
@@ -364,7 +364,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
                     'url' => 'civicrm/tasksassignments/settings',
                 )
             );
-            
+
             foreach ($submenu as $key => $item)
             {
                 $item['parent_id'] = $taNavigation->id;
@@ -372,13 +372,13 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
                 $item['is_active'] = 1;
                 CRM_Core_BAO_Navigation::add($item);
             }
-            
+
             CRM_Core_BAO_Navigation::resetNavigation();
         }
-        
+
         return TRUE;
     }
-    
+
     /*
      * Add Settings page to Administer top menu
      */
@@ -418,7 +418,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
 
             CRM_Core_BAO_Navigation::resetNavigation();
         }
-        
+
         return TRUE;
     }
 
@@ -468,21 +468,48 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
 
     return false;
   }
-    
+
+  /**
+   * Make sure that the Tasks and Assignments main menu item
+   * (and subsequently the Dashboard menu item) are restricted to only the users
+   * with 'access Tasks and Assignments' permission
+   */
+  public function upgrade_1018() {
+    $taNavigation = new CRM_Core_BAO_Navigation();
+    $taNavigation->name = 'tasksassignments';
+    $taNavigation->find(true);
+
+    if($taNavigation->id && !$taNavigation->permission) {
+      $navigation = new CRM_Core_BAO_Navigation();
+      $foo = array(
+        'id' => $taNavigation->id,
+        'permission' => 'access Tasks and Assignments',
+        'separator'  => 1,
+        'is_active'  => 1
+      );
+
+      $params = $navigation->add($foo);
+
+      return true;
+    }
+
+    return false;
+  }
+
     public function uninstall()
     {
         CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')");
         CRM_Core_BAO_Navigation::resetNavigation();
-        
+
         return TRUE;
     }
-  
+
     function _installTypes($component, array $types)
     {
         $administerNavId = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
         if ($administerNavId)
         {
-            
+
         }
         $componentId = null;
         $componentQuery = 'SELECT id FROM civicrm_component WHERE name = %1';

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -173,25 +173,30 @@ function tasksassignments_civicrm_pageRun($page) {
 function tasksassignments_civicrm_tabs(&$tabs) {
     CRM_Tasksassignments_Page_Tasksassignments::registerScripts();
 
-    $tabs[] = Array(
+    if (CRM_Core_Permission::check('access Tasks and Assignments')) {
+      $tabs[] = Array(
         'id'        => 'civitasks',
         'url'       => CRM_Utils_System::url('civicrm/contact/view/tasks'),
         'title'     => ts('Tasks'),
         'weight'    => 40
-    );
-
-    $documentsTab = civicrm_api3('TASettings', 'get', array(
-        'fields' => 'documents_tab',
-    ));
-    if ($documentsTab['values']['documents_tab']['value']) {
-        $tabs[] = Array(
-            'id'        => 'cividocuments',
-            'url'       => CRM_Utils_System::url('civicrm/contact/view/documents'),
-            'title'     => ts('Documents'),
-            'weight'    => 50
-        );
+      );
     }
 
+    $documentsTab = civicrm_api3('TASettings', 'get', array(
+      'fields' => 'documents_tab',
+    ));
+
+    if (
+      CRM_Core_Permission::check('access Tasks and Assignments') &&
+      $documentsTab['values']['documents_tab']['value']
+    ) {
+      $tabs[] = Array(
+        'id'        => 'cividocuments',
+        'url'       => CRM_Utils_System::url('civicrm/contact/view/documents'),
+        'title'     => ts('Documents'),
+        'weight'    => 50
+      );
+    }
 }
 
 /**

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -171,25 +171,21 @@ function tasksassignments_civicrm_pageRun($page) {
  */
 
 function tasksassignments_civicrm_tabs(&$tabs) {
-    CRM_Tasksassignments_Page_Tasksassignments::registerScripts();
+  CRM_Tasksassignments_Page_Tasksassignments::registerScripts();
 
-    if (CRM_Core_Permission::check('access Tasks and Assignments')) {
-      $tabs[] = Array(
-        'id'        => 'civitasks',
-        'url'       => CRM_Utils_System::url('civicrm/contact/view/tasks'),
-        'title'     => ts('Tasks'),
-        'weight'    => 40
-      );
-    }
+  if (CRM_Core_Permission::check('access Tasks and Assignments')) {
+    $tabs[] = Array(
+      'id'        => 'civitasks',
+      'url'       => CRM_Utils_System::url('civicrm/contact/view/tasks'),
+      'title'     => ts('Tasks'),
+      'weight'    => 40
+    );
 
     $documentsTab = civicrm_api3('TASettings', 'get', array(
       'fields' => 'documents_tab',
     ));
 
-    if (
-      CRM_Core_Permission::check('access Tasks and Assignments') &&
-      $documentsTab['values']['documents_tab']['value']
-    ) {
+    if (!empty($documentsTab['values']['documents_tab']['value'])) {
       $tabs[] = Array(
         'id'        => 'cividocuments',
         'url'       => CRM_Utils_System::url('civicrm/contact/view/documents'),
@@ -197,6 +193,7 @@ function tasksassignments_civicrm_tabs(&$tabs) {
         'weight'    => 50
       );
     }
+  }
 }
 
 /**

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
@@ -27,13 +27,13 @@
     <path>civicrm/admin/options/activity_type</path>
     <page_callback>CRM_Tasksassignments_Page_Options</page_callback>
     <title>Options</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/tasksassignments/settings</path>
     <title>Settings</title>
     <page_callback>CRM_Tasksassignments_Page_Settings</page_callback>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM</access_arguments>
   </item>
 
   <!-- Redirects from reminder email to angular dashboard -->
@@ -53,7 +53,7 @@
     <path>civicrm/tasksassignments/keydatescsv</path>
     <page_callback>CRM_Tasksassignments_Page_KeyDatesCsv</page_callback>
     <title>KeyDatesCsv</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access Tasks and Assignments</access_arguments>
   </item>
 
   <!-- API endpoint for angular: file operations -->
@@ -61,30 +61,30 @@
     <path>civicrm/tasksassignments/file/list</path>
     <page_callback>CRM_Tasksassignments_Page_Files::fileList</page_callback>
     <title>FileList</title>
-    <!--<access_arguments>edit Documents</access_arguments>-->
+    <access_arguments>access Tasks and Assignments</access_arguments>
   </item>
   <item>
     <path>civicrm/tasksassignments/file/upload</path>
     <page_callback>CRM_Tasksassignments_Page_Files::fileUpload</page_callback>
     <title>FileSave</title>
-    <!--<access_arguments>edit Documents</access_arguments>-->
+    <access_arguments>access Tasks and Assignments</access_arguments>
   </item>
   <item>
     <path>civicrm/tasksassignments/file/display</path>
     <page_callback>CRM_Tasksassignments_Page_Files::fileDisplay</page_callback>
     <title>FileDisplay</title>
-    <!--<access_arguments>edit Documents</access_arguments>-->
+    <access_arguments>access Tasks and Assignments</access_arguments>
   </item>
   <item>
     <path>civicrm/tasksassignments/file/delete</path>
     <page_callback>CRM_Tasksassignments_Page_Files::fileDelete</page_callback>
     <title>FileDelete</title>
-    <!--<access_arguments>edit Documents</access_arguments>-->
+    <access_arguments>access Tasks and Assignments</access_arguments>
   </item>
   <item>
     <path>civicrm/tasksassignments/file/zip</path>
     <page_callback>CRM_Tasksassignments_Page_Files::fileZip</page_callback>
     <title>FileZip</title>
-    <!--<access_arguments>edit Documents</access_arguments>-->
+    <access_arguments>access Tasks and Assignments</access_arguments>
   </item>
 </menu>

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
@@ -1,11 +1,28 @@
 <?xml version="1.0"?>
 <menu>
+  <!-- Main Dashboard -->
+  <item>
+    <path>civicrm/tasksassignments/dashboard</path>
+    <page_callback>CRM_Tasksassignments_Page_Dashboard</page_callback>
+    <title>Dashboard</title>
+    <access_arguments>access Tasks and Assignments</access_arguments>
+  </item>
+
+  <!-- Contact Tabs -->
   <item>
     <path>civicrm/contact/view/tasks</path>
     <page_callback>CRM_Tasksassignments_Page_Tasks</page_callback>
     <title>Tasks</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access Tasks and Assignments</access_arguments>
   </item>
+  <item>
+    <path>civicrm/contact/view/documents</path>
+    <page_callback>CRM_Tasksassignments_Page_Documents</page_callback>
+    <title>Documents</title>
+    <access_arguments>access Tasks and Assignments</access_arguments>
+  </item>
+
+  <!-- Admin -->
   <item>
     <path>civicrm/admin/options/activity_type</path>
     <page_callback>CRM_Tasksassignments_Page_Options</page_callback>
@@ -13,23 +30,33 @@
     <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
-    <path>civicrm/tasksassignments/dashboard</path>
-    <page_callback>CRM_Tasksassignments_Page_Dashboard</page_callback>
-    <title>Dashboard</title>
+    <path>civicrm/tasksassignments/settings</path>
+    <title>Settings</title>
+    <page_callback>CRM_Tasksassignments_Page_Settings</page_callback>
     <access_arguments>access CiviCRM</access_arguments>
+  </item>
+
+  <!-- Redirects from reminder email to angular dashboard -->
+  <item>
+    <path>civicrm/tasksassignments/my-tasks</path>
+    <page_callback>CRM_Tasksassignments_Page_MyTasks</page_callback>
+    <title>MyTasks</title>
   </item>
   <item>
-    <path>civicrm/contact/view/documents</path>
-    <page_callback>CRM_Tasksassignments_Page_Documents</page_callback>
-    <title>Documents</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <path>civicrm/tasksassignments/my-documents</path>
+    <page_callback>CRM_Tasksassignments_Page_MyDocuments</page_callback>
+    <title>MyDocuments</title>
   </item>
+
+  <!-- API endpoint for angular: key dates -->
   <item>
     <path>civicrm/tasksassignments/keydatescsv</path>
     <page_callback>CRM_Tasksassignments_Page_KeyDatesCsv</page_callback>
     <title>KeyDatesCsv</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+
+  <!-- API endpoint for angular: file operations -->
   <item>
     <path>civicrm/tasksassignments/file/list</path>
     <page_callback>CRM_Tasksassignments_Page_Files::fileList</page_callback>
@@ -59,20 +86,5 @@
     <page_callback>CRM_Tasksassignments_Page_Files::fileZip</page_callback>
     <title>FileZip</title>
     <!--<access_arguments>edit Documents</access_arguments>-->
-  </item>
-  <item>
-    <path>civicrm/tasksassignments/settings</path>
-    <page_callback>CRM_Tasksassignments_Page_Settings</page_callback>
-    <title>Settings</title>
-  </item>
-  <item>
-    <path>civicrm/tasksassignments/my-tasks</path>
-    <page_callback>CRM_Tasksassignments_Page_MyTasks</page_callback>
-    <title>MyTasks</title>
-  </item>
-  <item>
-    <path>civicrm/tasksassignments/my-documents</path>
-    <page_callback>CRM_Tasksassignments_Page_MyDocuments</page_callback>
-    <title>MyDocuments</title>
   </item>
 </menu>


### PR DESCRIPTION
#### Problem 
The "Tasks and Assignments" main menu item and the "Tasks" and "Assignments" tabs in the contact page were visible and accessible even if the user didn't have the "access Tasks and Assignments" credentials assigned to it

Also, the `access_arguments` values weren't specific enough for some of the pages defined in `tasksassignments.xml`

### Solution
In the `tasksassignments_civicrm_tabs` hook, the tabs are added only if the user has the credential
```php
function tasksassignments_civicrm_tabs(&$tabs) {
  if (CRM_Core_Permission::check('access Tasks and Assignments')) {
    $tabs[] = Array(/* ... */);
  }
```
The upgrader function that adds the T&A main menu item (`upgrade_0002`) has been amended so that it sets the permission correctly on it, but to be sure that the change is applied retroactively, a new upgrader has also been added which enforces the permission

The `taskassignments.xml` has been refactored so that the pages are better grouped, and some of the pages have now more specific restrictions