### PR TITLE
PCHR-1160 - Making 'source_contact_id', 'target_contact_id' and 'assignee_contact_id' required fields when creating Task / Document on BAO level.

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -12,6 +12,14 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
     {
         $entityName = 'Document';
         $hook = empty($params['id']) ? 'create' : 'edit';
+
+        if ($hook === 'create') {
+            // If creating a new Document, we require all three contacts to be defined.
+            if (empty($params['source_contact_id'] || empty($params['target_contact_id']) || empty($params['assignee_contact_id']))) {
+                throw new CiviCRM_API3_Exception("Please specify 'source_contact_id', 'target_contact_id' and 'assignee_contact_id'.");
+            }
+        }
+
         CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
         
         if (empty($params['status_id']) && $hook === 'create')

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -15,18 +15,16 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
 
         if ($hook === 'create') {
             // If creating a new Document, we require all three contacts to be defined.
-            if (empty($params['source_contact_id'] || empty($params['target_contact_id']) || empty($params['assignee_contact_id']))) {
-                throw new CiviCRM_API3_Exception("Please specify 'source_contact_id', 'target_contact_id' and 'assignee_contact_id'.");
+            if (empty($params['source_contact_id']) || empty($params['target_contact_id']) || empty($params['assignee_contact_id'])) {
+                throw new CRM_Exception("Please specify 'source_contact_id', 'target_contact_id' and 'assignee_contact_id'.");
+            }
+            if (empty($params['status_id'])) {
+                $params['status_id'] = 1;
             }
         }
 
         CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-        
-        if (empty($params['status_id']) && $hook === 'create')
-        {
-            $params['status_id'] = 1;
-        }
-        
+
         $instance = parent::create($params);
         CRM_Tasksassignments_Reminder::sendReminder((int)$instance->id);
         

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Task.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Task.php
@@ -13,16 +13,15 @@ class CRM_Tasksassignments_BAO_Task extends CRM_Tasksassignments_DAO_Task {
 
     if ($hook === 'create') {
         // If creating a new Task, we require all three contacts to be defined.
-        if (empty($params['source_contact_id'] || empty($params['target_contact_id']) || empty($params['assignee_contact_id']))) {
-            throw new CiviCRM_API3_Exception("Please specify 'source_contact_id', 'target_contact_id' and 'assignee_contact_id'.");
+        if (empty($params['source_contact_id']) || empty($params['target_contact_id']) || empty($params['assignee_contact_id'])) {
+            throw new CRM_Exception("Please specify 'source_contact_id', 'target_contact_id' and 'assignee_contact_id'.");
+        }
+        if (empty($params['status_id'])) {
+          $params['status_id'] = 1;
         }
     }
 
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
-
-    if (empty($params['status_id']) && $hook === 'create') {
-      $params['status_id'] = 1;
-    }
 
     $currentInstance = new static();
     $currentInstance->get('id', $params['id']);

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Task.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Task.php
@@ -11,6 +11,13 @@ class CRM_Tasksassignments_BAO_Task extends CRM_Tasksassignments_DAO_Task {
     $entityName = 'Task';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
+    if ($hook === 'create') {
+        // If creating a new Task, we require all three contacts to be defined.
+        if (empty($params['source_contact_id'] || empty($params['target_contact_id']) || empty($params['assignee_contact_id']))) {
+            throw new CiviCRM_API3_Exception("Please specify 'source_contact_id', 'target_contact_id' and 'assignee_contact_id'.");
+        }
+    }
+
     CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
 
     if (empty($params['status_id']) && $hook === 'create') {

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/Api/DocumentTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/Api/DocumentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Class Api_DocumentTest
+ */
+class Api_DocumentTest extends CiviUnitTestCase {
+  private $_documentTypeId = null;
+
+  function setUp() {
+    parent::setUp();
+    $upgrader = CRM_Tasksassignments_Upgrader::instance();
+    $upgrader->install();
+
+    // Pick one of Document types.
+    $documentTypes = civicrm_api3('Document', 'getoptions', array(
+      'field' => 'activity_type_id',
+    ));
+    $this->_documentTypeId = array_shift($documentTypes['values']);
+  }
+
+  function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   */
+  function testCreateDocumentWithNoContacts() {
+    civicrm_api3('Document', 'create', array(
+      'activity_type_id' => $this->_documentTypeId,
+    ));
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   */
+  function testCreateDocumentWithNoSource() {
+    civicrm_api3('Document', 'create', array(
+      'activity_type_id' => $this->_documentTypeId,
+      'assignee_contact_id' => 1,
+      'target_contact_id' => 2,
+    ));
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   */
+  function testCreateDocumentWithNoAssignee() {
+    civicrm_api3('Document', 'create', array(
+      'activity_type_id' => $this->_documentTypeId,
+      'source_contact_id' => 1,
+      'target_contact_id' => 2,
+    ));
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   */
+  function testCreateDocumentWithNoTarget() {
+    civicrm_api3('Document', 'create', array(
+      'activity_type_id' => $this->_documentTypeId,
+      'source_contact_id' => 1,
+      'assignee_contact_id' => 2,
+    ));
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/Api/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/Api/TaskTest.php
@@ -1,0 +1,69 @@
+<?php
+
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Class Api_TaskTest
+ */
+class Api_TaskTest extends CiviUnitTestCase {
+  private $_taskTypeId = null;
+
+  function setUp() {
+    parent::setUp();
+    $upgrader = CRM_Tasksassignments_Upgrader::instance();
+    $upgrader->install();
+
+    // Pick one of Task types.
+    $taskTypes = civicrm_api3('Task', 'getoptions', array(
+      'field' => 'activity_type_id',
+    ));
+    $this->_taskTypeId = array_shift($taskTypes['values']);
+  }
+
+  function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   */
+  function testCreateTaskWithNoContacts() {
+    civicrm_api3('Task', 'create', array(
+      'activity_type_id' => $this->_taskTypeId,
+    ));
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   */
+  function testCreateTaskWithNoSource() {
+    civicrm_api3('Task', 'create', array(
+      'activity_type_id' => $this->_taskTypeId,
+      'assignee_contact_id' => 1,
+      'target_contact_id' => 2,
+    ));
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   */
+  function testCreateTaskWithNoAssignee() {
+    civicrm_api3('Task', 'create', array(
+      'activity_type_id' => $this->_taskTypeId,
+      'source_contact_id' => 1,
+      'target_contact_id' => 2,
+    ));
+  }
+
+  /**
+   * @expectedException CiviCRM_API3_Exception
+   */
+  function testCreateTaskWithNoTarget() {
+    civicrm_api3('Task', 'create', array(
+      'activity_type_id' => $this->_taskTypeId,
+      'source_contact_id' => 1,
+      'assignee_contact_id' => 2,
+    ));
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/DocumentTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/DocumentTest.php
@@ -1,0 +1,73 @@
+<?php
+
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Class CRM_Tasksassignments_BAO_DocumentTest
+ */
+class CRM_Tasksassignments_BAO_DocumentTest extends CiviUnitTestCase {
+  private $_documentTypeId = null;
+
+  function setUp() {
+    parent::setUp();
+    $upgrader = CRM_Tasksassignments_Upgrader::instance();
+    $upgrader->install();
+
+    // Pick one of Document types.
+    $documentTypes = civicrm_api3('Document', 'getoptions', array(
+      'field' => 'activity_type_id',
+    ));
+    $this->_documentTypeId = array_shift($documentTypes['values']);
+  }
+
+  function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * @expectedException CRM_Exception
+   */
+  function testCreateDocumentWithNoContacts() {
+    $params = array(
+      'activity_type_id' => $this->_documentTypeId,
+    );
+    CRM_Tasksassignments_BAO_Document::create($params);
+  }
+
+  /**
+   * @expectedException CRM_Exception
+   */
+  function testCreateDocumentWithNoSource() {
+    $params = array(
+      'activity_type_id' => $this->_documentTypeId,
+      'assignee_contact_id' => 1,
+      'target_contact_id' => 2,
+    );
+    CRM_Tasksassignments_BAO_Document::create($params);
+  }
+
+  /**
+   * @expectedException CRM_Exception
+   */
+  function testCreateDocumentWithNoAssignee() {
+    $params = array(
+      'activity_type_id' => $this->_documentTypeId,
+      'source_contact_id' => 1,
+      'target_contact_id' => 2,
+    );
+    CRM_Tasksassignments_BAO_Document::create($params);
+  }
+
+  /**
+   * @expectedException CRM_Exception
+   */
+  function testCreateDocumentWithNoTarget() {
+    $params = array(
+      'activity_type_id' => $this->_documentTypeId,
+      'source_contact_id' => 1,
+      'assignee_contact_id' => 2,
+    );
+    CRM_Tasksassignments_BAO_Document::create($params);
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
@@ -1,0 +1,73 @@
+<?php
+
+
+require_once 'CiviTest/CiviUnitTestCase.php';
+
+/**
+ * Class CRM_Tasksassignments_BAO_TaskTest
+ */
+class CRM_Tasksassignments_BAO_TaskTest extends CiviUnitTestCase {
+  private $_taskTypeId = null;
+
+  function setUp() {
+    parent::setUp();
+    $upgrader = CRM_Tasksassignments_Upgrader::instance();
+    $upgrader->install();
+
+    // Pick one of Task types.
+    $taskTypes = civicrm_api3('Task', 'getoptions', array(
+      'field' => 'activity_type_id',
+    ));
+    $this->_taskTypeId = array_shift($taskTypes['values']);
+  }
+
+  function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * @expectedException CRM_Exception
+   */
+  function testCreateTaskWithNoContacts() {
+    $params = array(
+      'activity_type_id' => $this->_taskTypeId,
+    );
+    CRM_Tasksassignments_BAO_Task::create($params);
+  }
+
+  /**
+   * @expectedException CRM_Exception
+   */
+  function testCreateTaskWithNoSource() {
+    $params = array(
+      'activity_type_id' => $this->_taskTypeId,
+      'assignee_contact_id' => 1,
+      'target_contact_id' => 2,
+    );
+    CRM_Tasksassignments_BAO_Task::create($params);
+  }
+
+  /**
+   * @expectedException CRM_Exception
+   */
+  function testCreateTaskWithNoAssignee() {
+    $params = array(
+      'activity_type_id' => $this->_taskTypeId,
+      'source_contact_id' => 1,
+      'target_contact_id' => 2,
+    );
+    CRM_Tasksassignments_BAO_Task::create($params);
+  }
+
+  /**
+   * @expectedException CRM_Exception
+   */
+  function testCreateTaskWithNoTarget() {
+    $params = array(
+      'activity_type_id' => $this->_taskTypeId,
+      'source_contact_id' => 1,
+      'assignee_contact_id' => 2,
+    );
+    CRM_Tasksassignments_BAO_Task::create($params);
+  }
+}


### PR DESCRIPTION
Task / Document entities were handling creation logic the same way as original Activity entity so these three contact fields were not required on API level when creating an entity instance. I've modified both BAOs to require these contacts IDs when creating a new entity instance.