### PR TITLE
PCHR-1174: Document - Clicking on Contact name takes you to different…

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -236,7 +236,7 @@
 <script type="text/ng-template" id="document.html">
     <td class="{{prefix}}col-select"><input type="checkbox" checklist-model="checklist.selected[pagination.currentPage]" checklist-value="document" ng-change="toggleIsCheckedAll()"></td>
     <td><a ng-href="{{urlFile}}" ng-click="(!document.file_count || document.file_count == '0') && modalDocument(document, $event);" ng-bind="cache.documentType.obj[document.activity_type_id]"></a></td>
-    <td><a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[document.assignee_contact_id[0]].id}}" ng-bind="cache.contact.obj[document.assignee_contact_id[0]].sort_name"></a></td>
+    <td><a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[document.assignee_contact_id[0]].contact_id}}" ng-bind="cache.contact.obj[document.assignee_contact_id[0]].sort_name"></a></td>
     <td ng-if="settings.extEnabled.assignments" ng-bind="(cache.assignmentType.obj[cache.assignment.obj[document.case_id].case_type_id].title || '-')"></td>
     <td ng-bind="(document.activity_date_time | date: 'dd/MM/yyyy') || '-'"></td>
     <td ng-bind="(document.expire_date | date: 'dd/MM/yyyy') || '-'"></td>


### PR DESCRIPTION
Issue:
In Tasks and Assignments / Documents page, clicking on a Contact name was taking users to incorrect contact's page.

Example: 
Clicking on "krish, madu" should go to CID=220, but instead it was pointing to CID=67

<img width="742" alt="screen shot 2016-06-09 at 14 05 39" src="https://cloud.githubusercontent.com/assets/18520391/16528064/a4fc0310-3fba-11e6-9564-31f6c7764170.png">

The issue was located in the template file (documents.html), where the link's url was incorrectly being created using the "id" property, instead of the expected "contact_id".

To better understand it, below is an example of "cache.contact.obj" state, where the issue can be seeing:
![cache](https://cloud.githubusercontent.com/assets/18520391/16529101/3f0d41e8-3fc1-11e6-979e-6fe0da6b6d06.png)


