### PR TITLE
PCHR-1477: Remove the "Assignments" tab and the "Cases" top nav item

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -438,26 +438,6 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
   }
 
   /**
-   * Disables the Case menu items if Tasks&Assignments is enabled
-   *
-   * @return {boolean}
-   */
-  public function upgrade_1017()
-  {
-    $isEnabled = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'uk.co.compucorp.civicrm.tasksassignments', 'is_active', 'full_name');
-    $isCaseEnabled = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.hrcase', 'is_active', 'full_name');
-
-    if ($isEnabled && $isCaseEnabled) {
-      CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET is_active=0 WHERE name = 'Cases' AND parent_id IS NULL");
-      CRM_Core_BAO_Navigation::resetNavigation();
-
-      return true;
-    }
-
-    return false;
-  }
-
-  /**
    * Make sure that the Tasks and Assignments main menu item
    * (and subsequently the Dashboard menu item) are restricted to only the users
    * with 'access Tasks and Assignments' permission
@@ -482,6 +462,22 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     }
 
     return false;
+  }
+
+  /**
+   * Disables the Case menu items if Tasks&Assignments is enabled
+   *
+   * @return {boolean}
+   */
+  public function upgrade_1019() {
+    $isEnabled = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'uk.co.compucorp.civicrm.tasksassignments', 'is_active', 'full_name');
+
+    if ($isEnabled) {
+      CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET is_active=0 WHERE name = 'Cases' AND parent_id IS NULL");
+      CRM_Core_BAO_Navigation::resetNavigation();
+    }
+
+    return true;
   }
 
     public function uninstall()

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -50,8 +50,8 @@ function tasksassignments_civicrm_uninstall() {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
  */
 function tasksassignments_civicrm_enable() {
-  _toggleMenuItems();
-  if (_isCaseEnabled()) { _toggleCaseMenuItems(false); }
+  _tasksassignments_toggleMenuItems();
+  _tasksassignments_toggleCaseMenuItems(false);
 
   CRM_Core_BAO_Navigation::resetNavigation();
   _tasksassignments_civix_civicrm_enable();
@@ -67,8 +67,9 @@ function tasksassignments_civicrm_disable() {
   if (tasksassignments_checkHrcase())  {
     tasksassignments_extensionsPageRedirect();
   }
-  _toggleMenuItems(false);
-  if (_isCaseEnabled()) { _toggleCaseMenuItems(true); }
+
+  _tasksassignments_toggleMenuItems(false);
+  _tasksassignments_toggleCaseMenuItems();
 
   CRM_Core_BAO_Navigation::resetNavigation();
   _tasksassignments_civix_civicrm_disable();
@@ -219,21 +220,12 @@ function tasksassignments_civicrm_permission(&$permissions) {
 }
 
 /**
- * Checks if the Case extension is enabled
- *
- * @return {boolean}
- */
-function _isCaseEnabled() {
-  return CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Extension', 'org.civicrm.hrcase', 'is_active', 'full_name');
-}
-
-/**
  * Sets the is_state flag of its own menu items
  *
  * @param boolean $activate
  * @return void
  */
-function _toggleMenuItems($activate = true) {
+function _tasksassignments_toggleMenuItems($activate = true) {
   $is_active = $activate ? 1 : 0;
   $sql = "UPDATE civicrm_navigation SET is_active=$is_active WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')";
 
@@ -246,7 +238,7 @@ function _toggleMenuItems($activate = true) {
  * @param boolean $activate
  * @return void
  */
-function _toggleCaseMenuItems($activate = true) {
+function _tasksassignments_toggleCaseMenuItems($activate = true) {
   $is_active = $activate ? 1 : 0;
   $sql = "UPDATE civicrm_navigation SET is_active=$is_active WHERE name = 'Cases' AND parent_id IS NULL";
 

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Dashboard.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Dashboard.tpl
@@ -41,24 +41,12 @@
                             <span class="{$prefix}sidebar-main-title">Documents</span>
                         </a>
                     </li>
-                    <li ng-if="settings.extEnabled.assignments" ng-class="{literal}{ active: isActive('assignments')}{/literal}">
-                        <a href="#/assignments">
-                            <i class="fa fa-briefcase"></i>
-                            <span class="{$prefix}sidebar-main-title">Assignments</span>
-                        </a>
-                    </li>
                     <li ng-class="{literal}{ active: isActive('calendar')}{/literal}">
                         <a href="#/calendar">
                             <i class="fa fa-calendar"></i>
                             <span class="{$prefix}sidebar-main-title">Calendar</span>
                         </a>
                     </li>
-                    <!--<li ng-class="{literal}{ active: isActive('reports')}{/literal}">
-                        <a href="#/reports">
-                            <i class="fa fa-bar-chart"></i>
-                            <span class="{$prefix}sidebar-main-title">Reports</span>
-                        </a>
-                    </li>-->
                     <li ng-if="settings.tabEnabled.keyDates == '1'" ng-class="{literal}{ active: isActive('keyDates')}{/literal}">
                         <a href="#/key-dates">
                             <i class="fa fa-birthday-cake"></i>

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Dashboard.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Dashboard.tpl
@@ -2,89 +2,85 @@
 {assign var="prefix" value="ct-" }
 
 <div id="{$module}" class="{$prefix}page-loading" ng-controller="MainCtrl">
-    <div class="container-fluid">
-        <div id="{$prefix}dashboard">
-            <div class="{$prefix}top-bar" ng-controller="TopBarCtrl">
-                <div class="row">
-                    <div class="col-xs-12 col-sm-8">
-                        <ol class="breadcrumb">
-                            <li><a href="#">CiviHR</a></li>
-                            <li class="active">Dashboard</li>
-                        </ol>
-                    </div>
-                    <div class="col-xs-12 col-sm-4">
-                        <div class="btn-group pull-right">
-                            <a class="btn" ng-click="itemAdd.fn()">
-                                <span class="fa fa-plus-circle" aria-hidden="true"></span> &nbsp;
-                                {literal}{{itemAdd.label()}}{/literal}
-                            </a>
-
-                            <a class="btn" ng-click="modalAssignment()" ng-if="settings.extEnabled.assignments">
-                                <span class="fa fa-plus-circle" aria-hidden="true"></span> &nbsp;
-                                {literal}{{settings.copy.button.assignmentAdd || 'Add Assignment'}}{/literal}
-                            </a>
-                        </div>
-                    </div>
-                </div>
+  <div class="container-fluid">
+    <div id="{$prefix}dashboard">
+      <div class="{$prefix}top-bar" ng-controller="TopBarCtrl">
+        <div class="row">
+          <div class="col-xs-12 col-sm-8">
+            <ol class="breadcrumb">
+              <li><a href="#">CiviHR</a></li>
+              <li class="active">Dashboard</li>
+            </ol>
+          </div>
+          <div class="col-xs-12 col-sm-4">
+            <div class="btn-group pull-right">
+              <a class="btn" ng-click="itemAdd.fn()">
+                <span class="fa fa-plus-circle" aria-hidden="true"></span> &nbsp;
+                {literal}{{itemAdd.label()}}{/literal}
+              </a>
+              <a class="btn" ng-click="modalAssignment()" ng-if="settings.extEnabled.assignments">
+                <span class="fa fa-plus-circle" aria-hidden="true"></span> &nbsp;
+                {literal}{{settings.copy.button.assignmentAdd || 'Add Assignment'}}{/literal}
+              </a>
             </div>
-            <div class="{$prefix}container-main">
-                <ul class="nav {$prefix}sidebar {$prefix}sidebar-main" ng-controller="NavMainCtrl">
-                    <li ng-class="{literal}{ active: isActive('tasks')}{/literal}">
-                        <a href="#/tasks">
-                            <i class="fa fa-list"></i>
-                            <span class="{$prefix}sidebar-main-title">Tasks</span>
-                        </a>
-                    </li>
-                    <li ng-if="settings.tabEnabled.documents == '1'" ng-class="{literal}{ active: isActive('documents')}{/literal}">
-                        <a href="#/documents">
-                            <i class="fa fa-files-o"></i>
-                            <span class="{$prefix}sidebar-main-title">Documents</span>
-                        </a>
-                    </li>
-                    <li ng-class="{literal}{ active: isActive('calendar')}{/literal}">
-                        <a href="#/calendar">
-                            <i class="fa fa-calendar"></i>
-                            <span class="{$prefix}sidebar-main-title">Calendar</span>
-                        </a>
-                    </li>
-                    <li ng-if="settings.tabEnabled.keyDates == '1'" ng-class="{literal}{ active: isActive('keyDates')}{/literal}">
-                        <a href="#/key-dates">
-                            <i class="fa fa-birthday-cake"></i>
-                            <span class="{$prefix}sidebar-main-title">Key Dates</span>
-                        </a>
-                    </li>
-                </ul>
-                <div class="{$prefix}content-wrapper">
-                    <div class="{$prefix}content">
-                        <div ct-spinner ct-spinner-main-view>
-                            <div class="{$prefix}container-inner fade-in-up" ui-view>
-
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+          </div>
         </div>
+      </div>
+      <div class="{$prefix}container-main">
+        <ul class="nav {$prefix}sidebar {$prefix}sidebar-main" ng-controller="NavMainCtrl">
+          <li ng-class="{literal}{ active: isActive('tasks')}{/literal}">
+            <a href="#/tasks">
+              <i class="fa fa-list"></i>
+              <span class="{$prefix}sidebar-main-title">Tasks</span>
+            </a>
+          </li>
+          <li ng-if="settings.tabEnabled.documents == '1'" ng-class="{literal}{ active: isActive('documents')}{/literal}">
+            <a href="#/documents">
+              <i class="fa fa-files-o"></i>
+              <span class="{$prefix}sidebar-main-title">Documents</span>
+            </a>
+          </li>
+          <li ng-class="{literal}{ active: isActive('calendar')}{/literal}">
+            <a href="#/calendar">
+              <i class="fa fa-calendar"></i>
+              <span class="{$prefix}sidebar-main-title">Calendar</span>
+            </a>
+          </li>
+          <li ng-if="settings.tabEnabled.keyDates == '1'" ng-class="{literal}{ active: isActive('keyDates')}{/literal}">
+            <a href="#/key-dates">
+              <i class="fa fa-birthday-cake"></i>
+              <span class="{$prefix}sidebar-main-title">Key Dates</span>
+            </a>
+          </li>
+        </ul>
+        <div class="{$prefix}content-wrapper">
+          <div class="{$prefix}content">
+            <div ct-spinner ct-spinner-main-view>
+              <div class="{$prefix}container-inner fade-in-up" ui-view></div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+  </div>
 </div>
 {literal}
-    <script type="text/javascript">
-        (function(){
+  <script type="text/javascript">
+    (function(){
+      var detail = {
+        'app': 'appDashboard',
+        'module': 'civitasks'
+      };
 
-            var detail = {
-                'app': 'appDashboard',
-                'module': 'civitasks'
-            };
-
-            document.addEventListener('taReady', function(){
-                document.dispatchEvent(typeof window.CustomEvent == "function" ? new CustomEvent('taInit', {
-                    'detail': detail
-                }) : (function(){
-                    var e = document.createEvent('CustomEvent');
-                    e.initCustomEvent('taInit', true, true, detail);
-                    return e;
-                })());
-            });
-        })();
-    </script>
+      document.addEventListener('taReady', function(){
+        document.dispatchEvent(typeof window.CustomEvent == "function" ? new CustomEvent('taInit', {
+          'detail': detail
+        }) : (function(){
+          var e = document.createEvent('CustomEvent');
+          e.initCustomEvent('taInit', true, true, detail);
+          return e;
+        })());
+      });
+    })();
+  </script>
 {/literal}


### PR DESCRIPTION
**Before**
<img width="456" alt="before" src="https://cloud.githubusercontent.com/assets/6400898/17751782/f93b4e76-64c8-11e6-9299-f1e8936833f6.png">


**After**
<img width="446" alt="after" src="https://cloud.githubusercontent.com/assets/6400898/17751786/fc91f99e-64c8-11e6-9b79-e58587dc3a6c.png">


### Update
Also now the T&A extension, when enabled, will *always* remove the "Cases" main menu item, while before it was done only when `hrcase` was already enabled ("Cases" does not really belong to `hrcase`, but rather to CiviCRM in general, so there's no use in making that distinction based on `hrcase`).

The original upgrader was renamed as to be the newest  (i tested it and it doesn't seem to create any problem the fact that there is a "hole" between upgrades) 