### PR TITLE
PCHR-1476: Remove top padding

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -2952,7 +2952,6 @@
   text-decoration: none;
 }
 #civitasks a:focus, #cividocuments a:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -4507,7 +4506,6 @@
 #cividocuments input[type="radio"]:focus,
 #civitasks input[type="checkbox"]:focus,
 #cividocuments input[type="checkbox"]:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -5194,7 +5192,6 @@ fieldset[disabled]
   user-select: none;
 }
 #civitasks .btn:focus, #cividocuments .btn:focus, #civitasks .btn.focus, #cividocuments .btn.focus, #civitasks .btn:active:focus, #cividocuments .btn:active:focus, #civitasks .btn:active.focus, #cividocuments .btn:active.focus, #civitasks .btn.active:focus, #cividocuments .btn.active:focus, #civitasks .btn.active.focus, #cividocuments .btn.active.focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -10986,9 +10983,6 @@ fieldset[disabled]
 }
 #civitasks #ct-dashboard .ct-dashboard-tasks--full-height-columns > footer, #cividocuments #ct-dashboard .ct-dashboard-tasks--full-height-columns > footer {
   clear: both;
-}
-#civitasks #ct-dashboard, #cividocuments #ct-dashboard {
-  margin-top: 25px;
 }
 #civitasks #ct-dashboard .ct-container-main, #cividocuments #ct-dashboard .ct-container-main {
   position: relative;

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/.gitignore
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/.gitignore
@@ -1,1 +1,0 @@
-modules/_config.scss

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/modules/_config.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/modules/_config.scss
@@ -1,0 +1,2 @@
+$module-list:   'civitasks', 'cividocuments';
+$prefix:        'ct-';

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_dashboard.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_dashboard.scss
@@ -26,8 +26,6 @@
 }
 
 ##{$prefix}dashboard {
-  margin-top: 25px;
-
   .#{$prefix}container-main {
     position: relative;
     background-color: $sidebar-main-bg;


### PR DESCRIPTION
This PR remove the top padding from `#ct-dashboard` selector, and it was reverted `_config.scss` file to be able to generate CSS.

***Before***
![image](https://cloud.githubusercontent.com/assets/1280255/17891299/403dfa34-6911-11e6-9984-241692d8084b.png)


***After***
![image](https://cloud.githubusercontent.com/assets/1280255/17891287/32171756-6911-11e6-8fd5-4fb273b1e441.png)
