### PR TITLE
PCHR-1527: Fix add to assignment input when adding documents

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Assignment.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Assignment.php
@@ -21,4 +21,83 @@ class CRM_Tasksassignments_BAO_Assignment extends CRM_Tasksassignments_DAO_Assig
 
     return $instance;
   } */
+
+
+  /**
+   * Retrieve cases along with related contact details
+   *
+   * @param array $params Accept :
+   *  - 'sort_name' : Sort name for the user you want to retrieve cases for.
+   *  - 'limit' : The number of cases you want to retrieve.
+   * @param array $excludeCaseIds
+   *
+   * @return array Of case and related data keyed on case id
+   */
+  public static function retrieveCases($params = array(), $excludeCaseIds = array()) {
+    if ($sortName = CRM_Utils_Array::value('sort_name', $params)) {
+      $config = CRM_Core_Config::singleton();
+      $search = ($config->includeWildCardInName) ? "%$sortName%" : "$sortName%";
+      $where[] = "( sort_name LIKE '$search' )";
+    }
+    if (is_array($excludeCaseIds) &&
+      !CRM_Utils_System::isNull($excludeCaseIds)
+    ) {
+      $where[] = ' ( ca.id NOT IN ( ' . implode(',', $excludeCaseIds) . ' ) ) ';
+    }
+
+    $where[] = ' ( ca.is_deleted = 0 OR ca.is_deleted IS NULL ) ';
+
+    //filter for permissioned cases.
+    $filterCases = array();
+    $doFilterCases = FALSE;
+    if (!CRM_Core_Permission::check('access all cases and activities')) {
+      $doFilterCases = TRUE;
+      $session = CRM_Core_Session::singleton();
+      $filterCases = CRM_Case_BAO_Case::getCases(FALSE, $session->get('userID'));
+    }
+    $whereClause = implode(' AND ', $where);
+
+    $limitClause = '';
+    if ($limit = CRM_Utils_Array::value('limit', $params)) {
+      $limitClause = "LIMIT 0, $limit";
+    }
+
+    $query = "
+    SELECT  c.id as contact_id,
+            c.sort_name,
+            ca.id,
+            ca.subject as case_subject,
+            civicrm_case_type.title as case_type,
+            ca.start_date as start_date,
+            ca.end_date as end_date,
+            ca.status_id
+      FROM  civicrm_case ca INNER JOIN civicrm_case_contact cc ON ca.id=cc.case_id
+ INNER JOIN  civicrm_contact c ON cc.contact_id=c.id
+ INNER JOIN  civicrm_case_type ON ca.case_type_id = civicrm_case_type.id
+     WHERE  {$whereClause}
+  ORDER BY  c.sort_name, ca.end_date
+            {$limitClause}
+";
+    $dao = CRM_Core_DAO::executeQuery($query);
+    $statuses = CRM_Case_BAO_Case::buildOptions('status_id', 'create');
+
+    $cases = array();
+    while ($dao->fetch()) {
+      if ($doFilterCases && !array_key_exists($dao->id, $filterCases)) {
+        continue;
+      }
+      $cases[$dao->id] = array(
+        'sort_name' => $dao->sort_name,
+        'case_type' => $dao->case_type,
+        'contact_id' => $dao->contact_id,
+        'start_date' => $dao->start_date,
+        'end_date' => $dao->end_date,
+        'case_subject' => $dao->case_subject,
+        'case_status' => $statuses[$dao->status_id],
+      );
+    }
+    $dao->free();
+
+    return $cases;
+  }
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/AJAX.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/AJAX.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ +--------------------------------------------------------------------+
+ | CiviCRM version 4.5                                                |
+ +--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2014                                |
+ +--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +--------------------------------------------------------------------+
+*/
+
+/**
+ *
+ * @package CRM
+ * @copyright CiviCRM LLC (c) 2004-2014
+ *
+ */
+
+/**
+ * This class contains all case related functions that are called using AJAX (jQuery)
+ */
+class CRM_Tasksassignments_Page_AJAX {
+
+  /**
+   * Retrieve cases for auto-complete input.
+   */
+  public static function autocompleteCases() {
+    $params = array(
+      'limit' => CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'search_autocomplete_count', NULL, 10),
+      'sort_name' => CRM_Utils_Type::escape(CRM_Utils_Array::value('term', $_GET, ''), 'String'),
+    );
+
+    $excludeCaseIds = array();
+    if (!empty($_GET['excludeCaseIds'])) {
+      $excludeCaseIds = explode(',', CRM_Utils_Type::escape($_GET['excludeCaseIds'], 'String'));
+    }
+    $unclosedCases = CRM_Tasksassignments_BAO_Assignment::retrieveCases($params, $excludeCaseIds);
+    $results = array();
+    foreach ($unclosedCases as $caseId => $details) {
+      $results[] = array(
+        'id' => $caseId,
+        'label' => $details['sort_name'] . ' - ' . $details['case_type'] . ($details['end_date'] ? ' (' . ts('closed') . ')' : ''),
+        'label_class' => $details['end_date'] ? 'strikethrough' : '',
+        'description' => array($details['case_subject'] . ' (' . $details['case_status'] . ')'),
+        'extra' => $details,
+      );
+    }
+    CRM_Utils_JSON::output($results);
+  }
+
+}
+

--- a/uk.co.compucorp.civicrm.tasksassignments/phpunit.xml.dist
+++ b/uk.co.compucorp.civicrm.tasksassignments/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/AssignmentTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/AssignmentTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ *
+ * @group headless
+ */
+class CRM_Tasksassignments_BAO_AssignmentTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, TransactionalInterface {
+
+  use TasksassignmentsTestTrait;
+
+  private $contact_id;
+
+  private $case_type_id;
+
+  private $open_status_id;
+
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp() {
+    // Create Contact
+    $params = ['first_name' => 'micky', 'last_name' => 'mouse'];
+    $this->contact_id = $this->createContact($params);
+    // Create Case Type
+    $params = ['name' => 'test_case_type', 'title' => 'Test Case Type', 'is_active' => 1];
+    $this->case_type_id = $this->createCaseType($params);
+    // Create Case Status option values
+    $params = ['name' => 'Opened', 'grouping' => 'Opened'];
+    $this->open_status_id = $this->createOptionValue($params, 'case_status');
+  }
+
+  public function testRetrieveCasesWithoutExcludeCaseIds() {
+    $casesFixtures = [
+      ['subject' => 'test case', 'end_date' => null],
+      ['subject' => 'test case2', 'end_date' => date('Ymd')]
+    ];
+
+    $defaultParams = [
+      'creator_id' => $this->contact_id,
+      'case_type_id' => $this->case_type_id,
+      'status_id' => $this->open_status_id,
+    ];
+
+    $createdCases = [];
+    foreach($casesFixtures as $caseFixture) {
+      $params = array_merge($defaultParams, $caseFixture);
+      $caseID = $this->createCase($params);
+      $createdCases[$caseID] = $params;
+    }
+
+    $cases = CRM_Tasksassignments_BAO_Assignment::retrieveCases();
+
+    $this->assertCount(count($createdCases), $cases);
+    foreach($cases as $caseID => $caseValues) {
+      $this->assertNotEmpty($createdCases[$caseID]);
+      $this->assertEquals($createdCases[$caseID]['subject'], $caseValues['case_subject']);
+      $this->assertEquals($this->contact_id, $caseValues['contact_id']);
+      $this->assertEquals('Opened', $caseValues['case_status']);
+    }
+  }
+
+  public function testRetrieveCasesWithExcludeCaseIds() {
+    $casesFixtures = [
+      ['subject' => 'test case', 'end_date' => date('Ymd')],
+      ['subject' => 'test case2', 'end_date' => date('Ymd')],
+      ['subject' => 'test case3', 'end_date' => date('Ymd')]
+    ];
+
+    $defaultParams = [
+      'creator_id' => $this->contact_id,
+      'case_type_id' => $this->case_type_id,
+      'status_id' => $this->open_status_id,
+    ];
+
+    $createdCases = [];
+    foreach($casesFixtures as $caseFixture) {
+      $params = array_merge($defaultParams, $caseFixture);
+      $caseID = $this->createCase($params);
+      $createdCases[$caseID] = $params;
+    }
+
+    $caseIDs = array_keys($createdCases);
+    $cases = CRM_Tasksassignments_BAO_Assignment::retrieveCases([], [$caseIDs[0], $caseIDs[1]]);
+
+    $currentKey = $caseIDs[2];
+    $this->assertCount(1, $cases);
+    $this->assertNotEmpty($cases[$currentKey]);
+    $this->assertEquals($createdCases[$currentKey]['subject'], $cases[$currentKey]['case_subject']);
+    $this->assertEquals($this->contact_id, $cases[$currentKey]['contact_id']);
+    $this->assertEquals('Opened', $cases[$currentKey]['case_status']);
+  }
+
+  public function testRetrieveCasesWithLimit() {
+    $casesFixtures = [
+      ['subject' => 'test case', 'end_date' => date('Ymd')],
+      ['subject' => 'test case2', 'end_date' => date('Ymd', strtotime('+2 days'))],
+      ['subject' => 'test case3', 'end_date' => date('Ymd', strtotime('+4 days'))]
+    ];
+
+    $defaultParams = [
+      'creator_id' => $this->contact_id,
+      'case_type_id' => $this->case_type_id,
+      'status_id' => $this->open_status_id,
+    ];
+
+    $createdCases = [];
+    foreach($casesFixtures as $caseFixture) {
+      $params = array_merge($defaultParams, $caseFixture);
+      $caseID = $this->createCase($params);
+      $createdCases[$caseID] = $params;
+    }
+
+    $caseIDs = array_keys($createdCases);
+    $cases = CRM_Tasksassignments_BAO_Assignment::retrieveCases(['limit' => 1]);
+
+    $currentKey = $caseIDs[0];
+    $this->assertCount(1, $cases);
+    $this->assertNotEmpty($cases[$currentKey]);
+    $this->assertEquals($createdCases[$currentKey]['subject'], $cases[$currentKey]['case_subject']);
+    $this->assertEquals($this->contact_id, $cases[$currentKey]['contact_id']);
+    $this->assertEquals('Opened', $cases[$currentKey]['case_status']);
+  }
+
+  public function testRetrieveCasesWithSortName() {
+    // Create another contact
+    $params = ['first_name' => 'donald', 'last_name' => 'duck'];
+    $contact2 = $this->createContact($params);
+
+    $casesFixtures = [
+      ['subject' => 'test case', 'creator_id' => $this->contact_id],
+      ['subject' => 'test case2', 'creator_id' => $this->contact_id],
+      ['subject' => 'test case3', 'creator_id' => $contact2]
+    ];
+
+    $defaultParams = [
+      'case_type_id' => $this->case_type_id,
+      'status_id' => $this->open_status_id,
+    ];
+
+    $createdCases = [];
+    foreach($casesFixtures as $caseFixture) {
+      $params = array_merge($defaultParams, $caseFixture);
+      $caseID = $this->createCase($params);
+      $createdCases[$caseID] = $params;
+    }
+
+    $caseIDs = array_keys($createdCases);
+    $cases = CRM_Tasksassignments_BAO_Assignment::retrieveCases(['sort_name' => 'duck']);
+
+    $currentKey = $caseIDs[2];
+    $this->assertCount(1, $cases);
+    $this->assertNotEmpty($cases[$currentKey]);
+    $this->assertEquals($createdCases[$currentKey]['subject'], $cases[$currentKey]['case_subject']);
+    $this->assertEquals($contact2, $cases[$currentKey]['contact_id']);
+    $this->assertEquals('Opened', $cases[$currentKey]['case_status']);
+  }
+}
+

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/TasksassignmentsTestTrait.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/TasksassignmentsTestTrait.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * A trait with helper methods to be reused among this extension's tests
+ */
+trait TasksassignmentsTestTrait {
+
+  /**
+   * Creates single (Individuals) contact from the provided data.
+   *
+   * @param array $params Should contain first_name and last_name
+   *
+   * @return int Contact ID
+   */
+  protected function createContact($params) {
+    if (empty($params['contact_type'])) {
+      $params['contact_type'] = "Individual";
+    }
+    $params['display_name'] = $params['first_name'] . ' ' . $params['last_name'];
+    $contact = CRM_Contact_BAO_Contact::create($params);
+
+    return $contact->id;
+  }
+
+  /**
+   * Create case type
+   *
+   * @param array $params Should contain 'name'
+   *
+   * @return int|NULL Case type ID
+   */
+  protected function createCaseType($params) {
+    $caseType = CRM_Case_BAO_CaseType::create($params);
+    if (!empty($caseType->id)) {
+      return $caseType->id;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Create a new case
+   *
+   * @param array $params Should contain 'creator_id', 'case_type_id' and 'status_id'
+   *
+   * @return int|NULL Case ID
+   */
+  protected function createCase($params) {
+    $case = CRM_Case_BAO_Case::create($params);
+    if (!empty($case->id)) {
+      $contactParams = array('case_id' => $case->id, 'contact_id' => $params['creator_id']);
+      CRM_Case_BAO_CaseContact::create($contactParams);
+
+      return $case->id;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Create option value for a specific option group
+   * and if the group is not exist it will be created
+   * before creating the option value.
+   *
+   * @param array $params Should contain 'name'
+   * @param string $group Option group name
+   *
+   * @return string Option value (value)
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function createOptionValue($params, $group) {
+    $groupParams = ['name' => $group];
+    $defaults = NULL;
+    $optionGroup = CRM_Core_BAO_OptionGroup::retrieve($groupParams, $defaults);
+
+    if (empty($optionGroup->id)) {
+      $groupParams['is_active'] = 1;
+      $optionGroup = CRM_Core_BAO_OptionGroup::add($groupParams);
+    }
+    $optionGroupID = $optionGroup->id;
+
+    $params['option_group_id'] = $optionGroupID;
+    $params['sequential'] = 1;
+    $optionValue = civicrm_api3('OptionValue', 'create', $params);
+
+    return $optionValue['values'][0]['value'];
+  }
+
+
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/bootstrap.php
@@ -1,0 +1,51 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+eval(cv('php:boot --level=full -t', 'phpcode'));
+
+require_once 'TasksassignmentsTestTrait.php';
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
@@ -87,4 +87,9 @@
     <title>FileZip</title>
     <access_arguments>access Tasks and Assignments</access_arguments>
   </item>
+
+  <item>
+    <path>civicrm/case/ajax/unclosed</path>
+    <page_callback>CRM_Tasksassignments_Page_AJAX::autocompleteCases</page_callback>
+  </item>
 </menu>


### PR DESCRIPTION
## Problem 

When trying to search in  (add to assignment) box , it was not showing any result and a the following error appear in the console  :

```"Error in resource configuration for action `query`. Expected response to contain an array but got an object (Request: GET `/index.php?q=civicrm/case/ajax/unclosed)"```

The reason behind this is the deletion of this ajax end-point **civicrm/case/ajax/unclosed** in civicrm 4.7 and  a new quick-form method created **addEntityRef** to replace it . (https://github.com/civicrm/civicrm-core/commit/abd06efc426540ed16cb091093f90e13df2579f1)

## Solution

since we are working with angular and **addEntityRef** cannot be used since it is a quick-form method , I restored the **civicrm/case/ajax/unclosed** and the callback method **unclosedCases** in T&A extension.

So now the results are avaliable , but there is still a problem with the front-end part that need to be fixed in order for the fetched data to be shown.

![selection_101](https://cloud.githubusercontent.com/assets/6275540/18051638/7049e192-6dfe-11e6-8bbf-fb32a2308ab7.png)

