### PR TITLE
PCHR-1362 - Email notifications for documents

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -1,35 +1,40 @@
 <?php
 
-class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Document
-{
-    /**
-     * Create a new Document based on array-data
-     *
-     * @param array $params key-value pairs
-     * @return CRM_Tasksassignments_DAO_Document|NULL
-     */
-    public static function create(&$params)
-    {
-        $entityName = 'Document';
-        $hook = empty($params['id']) ? 'create' : 'edit';
+class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Document {
 
-        if ($hook === 'create') {
-            // If creating a new Document, we require all three contacts to be defined.
-            if (empty($params['source_contact_id']) || empty($params['target_contact_id']) || empty($params['assignee_contact_id'])) {
-                throw new CRM_Exception("Please specify 'source_contact_id', 'target_contact_id' and 'assignee_contact_id'.");
-            }
-            if (empty($params['status_id'])) {
-                $params['status_id'] = 1;
-            }
-        }
+  const STATUS_AWAITING_UPLOAD = 1;
+  const STATUS_AWAITING_APPROVAL = 2;
+  const STATUS_APPROVED = 3;
+  const STATUS_REJECTED = 4;
 
-        CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+  /**
+   * Create a new Document based on array-data
+   *
+   * @param array $params key-value pairs
+   * @return CRM_Tasksassignments_DAO_Document|NULL
+   */
+  public static function create(&$params) {
+    $entityName = 'Document';
+    $hook = empty($params['id']) ? 'create' : 'edit';
 
-        $instance = parent::create($params);
-        CRM_Tasksassignments_Reminder::sendReminder((int)$instance->id);
-        
-        CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
-        
-        return $instance;
+    if ($hook === 'create') {
+      // If creating a new Document, we require all three contacts to be defined.
+      if (empty($params['source_contact_id']) || empty($params['target_contact_id']) || empty($params['assignee_contact_id'])) {
+        throw new CRM_Exception("Please specify 'source_contact_id', 'target_contact_id' and 'assignee_contact_id'.");
+      }
+      if (empty($params['status_id'])) {
+        $params['status_id'] = 1;
+      }
     }
+
+    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+
+    $instance = parent::create($params);
+    CRM_Tasksassignments_Reminder::sendReminder((int) $instance->id);
+
+    CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
+
+    return $instance;
+  }
+
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -486,6 +486,171 @@ class CRM_Tasksassignments_Reminder
     }
 
     /**
+     * Sends out daily email notifications for documents including separate lists
+     * with:
+     * - Overdue documents (!= approved)
+     * - Due in next fortnight (14 days) (!= approved)
+     * - Due in < 90 days (!= approved)
+     * and show status in email.
+     * 
+     * Acceptance criteria:
+     * - Emails are sent out to assignees only.
+     * - Assignee contact receives lists of documents he/she is assigned to only.
+     * - Documents are grouped by due date according to the logic described
+     *   in the task description (@see PCHR-1362).
+     * 
+     * Returns a number of emails sent.
+     * 
+     * @return int
+     */
+    public static function sendDocumentsNotifications() {
+      self::_setActivityOptions();
+      $count = 0;
+      $taSettings = civicrm_api3('TASettings', 'get');
+      $settings = $taSettings['values'];
+      $notifications = self::getDocumentNotificationsData();
+      $myTasksUrl = CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#/tasks/my';
+      $myDocumentsUrl = CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#/documents/my';
+      foreach ($notifications as $assignee => $documentsSet) {
+        list($assigneeId, $assigneeEmail) = explode(':', $assignee);
+        $templateBodyHTML = CRM_Core_Smarty::singleton()->fetchWith('CRM/Tasksassignments/Reminder/DailyDocumentsNotification.tpl', array(
+          'notification' => $documentsSet,
+          'baseUrl' => CIVICRM_UF_BASEURL,
+          'myTasksUrl' => $myTasksUrl,
+          'myDocumentsUrl' => $myDocumentsUrl,
+          'settings' => $settings,
+        ));
+        if (self::_send($assigneeId, $assigneeEmail, t('Documents Notification'), $templateBodyHTML)) {
+          $count++;
+        }
+      }
+
+      return $count;
+    }
+
+    /**
+     * Return an array containing a set of Documents for each Assignee
+     * grouped by due date period ('overdue' - overdue, 'plus14' - due date
+     * within next 14 days, 'plus90' - due date within next 90 days).
+     * 
+     * @return array
+     */
+    protected static function getDocumentNotificationsData() {
+      $today = new DateTime();
+      $todayPlus14 = (new DateTime())->add(new DateInterval('P14D'));
+      $todayPlus90 = (new DateTime())->add(new DateInterval('P90D'));
+      $notifications = array();
+
+      $activityResult = self::queryDbForDocumentsNotificationData($todayPlus90);
+      while ($activityResult->fetch())
+      {
+        $activityContact = self::getExtractedActivityContacts($activityResult->activity_contact);
+        $dueDate = (new DateTime())->createFromFormat('Y-m-d', $activityResult->activity_date);
+        $assigneeId = $activityContact[self::ACTIVITY_CONTACT_ASSIGNEE]['id'];
+        if (empty($assigneeId)) {
+          continue;
+        }
+        $dueIndex = 'overdue';
+        if ($dueDate->format('Y-m-d') >= $today->format('Y-m-d')) {
+          $dueIndex = 'plus14';
+        }
+        if ($dueDate->format('Y-m-d') >= $todayPlus14->format('Y-m-d')) {
+          $dueIndex = 'plus90';
+        }
+        $key = $assigneeId . ':' . $activityContact[self::ACTIVITY_CONTACT_ASSIGNEE]['email'];
+        $notifications[$key][$dueIndex][] = self::getDocumentNotificationTemplateValues($activityResult, $activityContact);
+      }
+
+      return $notifications;
+    }
+
+    /**
+     * Return CRM_Core_DAO object with database results containing data
+     * needed for create a Documents Notification emails.
+     * 
+     * @param DateTime $upToDate
+     * @return CRM_Core_DAO
+     */
+    protected static function queryDbForDocumentsNotificationData(DateTime $upToDate) {
+      $activityQuery = "SELECT a.id, a.activity_type_id, a.status_id, DATE(a.activity_date_time) AS activity_date,
+        GROUP_CONCAT(ac.record_type_id, ':', ac.contact_id, ':', contact.display_name, ':', e.email SEPARATOR  %1) AS activity_contact
+        FROM `civicrm_activity` a
+        LEFT JOIN civicrm_activity_contact ac ON ac.activity_id = a.id
+        LEFT JOIN civicrm_contact contact ON contact.id = ac.contact_id
+        LEFT JOIN civicrm_email e ON e.contact_id = ac.contact_id AND e.is_primary = 1
+        WHERE a.status_id <> 3 AND
+          DATE(a.activity_date_time) <= %2 AND
+          a.activity_type_id IN (
+            SELECT value
+            FROM civicrm_option_value ov
+            LEFT JOIN civicrm_option_group og ON ov.option_group_id = og.id
+            LEFT JOIN civicrm_component co ON ov.component_id = co.id
+            WHERE og.name = 'activity_type'
+            AND co.name = 'CiviDocument'
+          )
+        GROUP BY a.id
+        ORDER BY a.id";
+      $activityParams = array(
+        1 => array(CRM_Core_DAO::VALUE_SEPARATOR, 'String'),
+        2 => array($upToDate->format('Y-m-d'), 'String'),
+      );
+      return CRM_Core_DAO::executeQuery($activityQuery, $activityParams);
+    }
+
+    /**
+     * Extracts data from a single row containing concatenated database values into
+     * array containing three contact types (Creator, Assignee and Target).
+     * 
+     * @param string $activityContactsData
+     * @return array
+     */
+    protected static function getExtractedActivityContacts($activityContactsData) {
+      $result = array(
+        self::ACTIVITY_CONTACT_CREATOR => array(),
+        self::ACTIVITY_CONTACT_ASSIGNEE => array(),
+        self::ACTIVITY_CONTACT_TARGET => array(),
+      );
+      $activityContactRows = explode(CRM_Core_DAO::VALUE_SEPARATOR, $activityContactsData);
+
+      foreach ($activityContactRows as $value)
+      {
+        list($type, $contactId, $contactDisplayName, $email) = explode(':', $value);
+        $result[$type] = array(
+          'id' => $contactId,
+          'url' => CIVICRM_UF_BASEURL . '/civicrm/contact/view?reset=1&cid=' . $contactId,
+          'displayName' => $contactDisplayName,
+          'email' => $email,
+        );
+      }
+
+      return $result;
+    }
+
+    /**
+     * Return an array containing a set of single Document fields needed for
+     * list the Document in notification template.
+     * 
+     * @param CRM_Core_DAO $activityResult
+     * @param array $activityContact
+     * 
+     * @return array
+     */
+    protected static function getDocumentNotificationTemplateValues(CRM_Core_DAO $activityResult, array $activityContact) {
+      return array(
+          'id' => $activityResult->id,
+          'activityUrl' => CIVICRM_UF_BASEURL . '/civicrm/activity/view?action=view&reset=1&id=' . $activityResult->id . '&cid=&context=activity&searchContext=activity',
+          'typeId' => $activityResult->activity_type_id,
+          'type' => self::$_activityOptions['type'][$activityResult->activity_type_id],
+          'statusId' => $activityResult->status_id,
+          'status' => self::$_activityOptions['document_status'][$activityResult->status_id],
+          'source' => $activityContact[self::ACTIVITY_CONTACT_CREATOR],
+          'target' => $activityContact[self::ACTIVITY_CONTACT_TARGET],
+          'assignee' => $activityContact[self::ACTIVITY_CONTACT_ASSIGNEE],
+          'date' => (new DateTime())->createFromFormat('Y-m-d', $activityResult->activity_date)->format('M d'),
+        );
+    }
+
+    /**
      * @param int $contactId
      * @param string $email
      * @param string $template

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -578,8 +578,8 @@ class CRM_Tasksassignments_Reminder
         LEFT JOIN civicrm_activity_contact ac ON ac.activity_id = a.id
         LEFT JOIN civicrm_contact contact ON contact.id = ac.contact_id
         LEFT JOIN civicrm_email e ON e.contact_id = ac.contact_id AND e.is_primary = 1
-        WHERE a.status_id <> 3 AND
-          DATE(a.activity_date_time) <= %2 AND
+        WHERE a.status_id <> %2 AND
+          DATE(a.activity_date_time) <= %3 AND
           a.activity_type_id IN (
             SELECT value
             FROM civicrm_option_value ov
@@ -592,7 +592,8 @@ class CRM_Tasksassignments_Reminder
         ORDER BY a.id";
       $activityParams = array(
         1 => array(CRM_Core_DAO::VALUE_SEPARATOR, 'String'),
-        2 => array($upToDate->format('Y-m-d'), 'String'),
+        2 => array(CRM_Tasksassignments_BAO_Document::STATUS_APPROVED, 'Integer'),
+        3 => array($upToDate->format('Y-m-d'), 'String'),
       );
       return CRM_Core_DAO::executeQuery($activityQuery, $activityParams);
     }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -501,6 +501,32 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     return TRUE;
   }
 
+  /*
+   * Set up Documents Notification job
+   */
+  public function upgrade_1021()
+  {
+    $dao = new CRM_Core_DAO_Job();
+    $dao->api_entity = 'document';
+    $dao->api_action = 'senddailynotification';
+    $dao->find(TRUE);
+    if (!$dao->id)
+    {
+      $dao = new CRM_Core_DAO_Job();
+      $dao->domain_id = CRM_Core_Config::domainID();
+      $dao->run_frequency = 'Daily';
+      $dao->parameters = null;
+      $dao->name = 'Tasks and Assignments Documents Notification';
+      $dao->description = 'Tasks and Assignments Documents Notification';
+      $dao->api_entity = 'document';
+      $dao->api_action = 'senddailynotification';
+      $dao->is_active = 1;
+      $dao->save();
+    }
+
+    return TRUE;
+  }
+
     public function uninstall()
     {
         CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')");

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -508,7 +508,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
   {
     $dao = new CRM_Core_DAO_Job();
     $dao->api_entity = 'document';
-    $dao->api_action = 'senddailynotification';
+    $dao->api_action = 'senddocumentsnotification';
     $dao->find(TRUE);
     if (!$dao->id)
     {
@@ -519,7 +519,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
       $dao->name = 'Tasks and Assignments Documents Notification';
       $dao->description = 'Tasks and Assignments Documents Notification';
       $dao->api_entity = 'document';
-      $dao->api_action = 'senddailynotification';
+      $dao->api_action = 'senddocumentsnotification';
       $dao->is_active = 1;
       $dao->save();
     }

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -764,3 +764,12 @@ function civicrm_api3_document_senddailyreminder($params) {
     CRM_Tasksassignments_Reminder::sendDailyReminder();
     return civicrm_api3_create_success(1, $params, 'document', 'dailyreminder');
 }
+
+/*
+ * Documents Notification scheduled job's entry point.
+ */
+function civicrm_api3_document_senddailynotification($params) {
+    
+    $count = CRM_Tasksassignments_Reminder::sendDocumentsNotifications();
+    return civicrm_api3_create_success($count, $params, 'document', 'senddailynotification');
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -768,8 +768,8 @@ function civicrm_api3_document_senddailyreminder($params) {
 /*
  * Documents Notification scheduled job's entry point.
  */
-function civicrm_api3_document_senddailynotification($params) {
+function civicrm_api3_document_senddocumentsnotification($params) {
     
     $count = CRM_Tasksassignments_Reminder::sendDocumentsNotifications();
-    return civicrm_api3_create_success($count, $params, 'document', 'senddailynotification');
+    return civicrm_api3_create_success($count, $params, 'document', 'senddocumentsnotification');
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/DailyDocumentsNotification.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/DailyDocumentsNotification.tpl
@@ -1,0 +1,28 @@
+{include file='CRM/Tasksassignments/Reminder/Header.tpl'}
+<span class="h4" style="color:#202020;display:block;font-family:Arial;font-size:22px;font-weight:normal;line-height:100%;margin-bottom:10px;text-align:left;">{ts}Daily Not Approved Documents Notification{/ts}</span>
+
+{if $notification.overdue}
+<span class="h4 dailyreminder overdue" style="color:#202020;display:block;font-family:Arial;font-size:18px;font-weight:normal;line-height:100%;margin-bottom:10px;text-align:left;margin-top: 16px;margin-bottom: 16px;">{ts}Overdue Documents{/ts} ({$notification.overdue|@count})</span>
+<hr style="height:0px;border:0px none;border-bottom:1px solid;border-color:#e0e0e0;margin:16px 0 10px;"/>
+    {foreach from=$notification.overdue item=row}
+        {include file='CRM/Tasksassignments/Reminder/Document.tpl'}
+    {/foreach}
+{/if}
+
+{if $notification.plus14}
+<span class="h4 dailyreminder coming-up" style="color:#202020;display:block;font-family:Arial;font-size:18px;font-weight:normal;line-height:100%;margin-bottom:10px;text-align:left;margin-top: 16px;margin-bottom: 16px;">{ts}Documents due in next fortnight{/ts} ({$notification.plus14|@count})</span>
+<hr style="height:0px;border:0px none;border-bottom:1px solid;border-color:#e0e0e0;margin:16px 0 10px;"/>
+    {foreach from=$notification.plus14 item=row}
+        {include file='CRM/Tasksassignments/Reminder/Document.tpl'}
+    {/foreach}
+{/if}
+
+{if $notification.plus90}
+<span class="h4 dailyreminder coming-up" style="color:#202020;display:block;font-family:Arial;font-size:18px;font-weight:normal;line-height:100%;margin-bottom:10px;text-align:left;margin-top: 16px;margin-bottom: 16px;">{ts}Documents due in next 90 days{/ts} ({$notification.plus90|@count})</span>
+<hr style="height:0px;border:0px none;border-bottom:1px solid;border-color:#e0e0e0;margin:16px 0 10px;"/>
+    {foreach from=$notification.plus90 item=row}
+        {include file='CRM/Tasksassignments/Reminder/Document.tpl'}
+    {/foreach}
+{/if}
+
+{include file='CRM/Tasksassignments/Reminder/Footer.tpl'}

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Document.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Document.tpl
@@ -1,0 +1,30 @@
+<table class="mtable" width="100%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+    <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+        <td width="80%" align="left" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+            <a href="{$row.activityUrl}" style="color:#42b0cb;font-weight:normal;text-decoration:underline;">{$row.type}</a>&nbsp;&nbsp;&nbsp;&nbsp;<span class="status-{$row.status}">{$row.status}</span>
+        </td>
+        <td align="right" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+                {$row.date}
+        </td>
+    </tr>
+    <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+        <td align="left" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+            <table class="mtable subtable" width="100%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;font-size: 12px;">
+                <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+                    <td width="100%" align="left" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+{if $row.source.displayName}
+                        {ts}Source Contact{/ts}: <a href="{$row.source.url}" style="color:#42b0cb;font-weight:normal;text-decoration:underline;">{$row.source.displayName}</a><br/>
+{/if}
+{if $row.target.displayName}
+                        {ts}Target Contact{/ts}: <a href="{$row.target.url}" style="color:#42b0cb;font-weight:normal;text-decoration:underline;">{$row.target.displayName}</a>
+{/if}
+                    </td>
+                </tr>
+            </table>
+        </td>
+        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+                &nbsp;
+        </td>
+    </tr>
+</table>
+<hr style="height:0px;border:0px none;border-bottom:1px solid;border-color:#e0e0e0;margin:16px 0 10px;"/>


### PR DESCRIPTION
Created 'senddocumentnotification' API action and BAO logic + Upgrader function installing daily scheduled job.

The new API action sends daily email notifications for documents including separate lists with:

- Overdue documents (!= approved)
- Due in next fortnight (14 days) (!= approved)
- Due in < 90 days (!= approved)

And show status in email.

Acceptance criteria:

- Emails are sent out to assignees only.
- Assignee contact receives lists of documents he/she is assigned to only
- Documents are grouped by due date according to the logic described in the task description

An exaple of email with documents notifications:
![documents_notification](https://cloud.githubusercontent.com/assets/8986209/18099799/8b6e576a-6ee8-11e6-93c4-0626e4ae227a.png)
