### PR TITLE
PCHR-1322: Removing "set status" option from document status dropdown

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
@@ -37,10 +37,13 @@ define([
                 assignee: initialContacts('assignee')
             };
 
-            $scope.statusFieldVisible = false;
+            $scope.statusFieldVisible = function() {
+              return !!$scope.document.status_id;
+            };
+
             $scope.showStatusField = function() {
-              $scope.statusFieldVisible = true;
-            }
+              $scope.document.status_id = 1;
+            };
 
             $scope.cacheAssignment = function ($item) {
 

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -201,23 +201,23 @@
                 </div>
             </div>
             <div class="row" ng-show="expanded">
-                <label class="col-xs-12 col-sm-6" ng-hide="statusFieldVisible">
+                <label class="col-xs-12 col-sm-6" ng-hide="statusFieldVisible()">
                     <span class="form-control-static">
                         <a href class="btn btn-indent" ng-click="showStatusField()">Set Status</a>
                     </span>
                 </label>
 
-                <div class="col-xs-12 col-sm-6" ng-show="statusFieldVisible">
-                    <div class="crm_custom-select crm_custom-select--full">
-                        <select
-                            ng-required
-                            class="form-control"
-                            ng-model="document.status_id"
-                            ng-options="status.key as status.value for status in cache.documentStatus.arr">
-                            <option value="">Set Status</option>
-                        </select>
-                        <span class="crm_custom-select__arrow"></span>
-                    </div>
+                <div class="col-xs-12 col-sm-6" ng-show="statusFieldVisible()">
+                    <ui-select theme="civihr-ui-select" ng-model="document.status_id">
+                        <ui-select-match allow-clear class="ui-select-match" placeholder="Set Status">
+                            {{$select.selected.value}}
+                        </ui-select-match>
+                        <ui-select-choices
+                            class="ui-select-choices"
+                            repeat="status.key as status in cache.documentStatus.arr | filter: $select.search">
+                            <div ng-bind="status.value"></div>
+                        </ui-select-choices>
+                    </ui-select>
                 </div>
                 <label class="col-xs-12 control-label">Details</label>
                 <div class="col-xs-12">


### PR DESCRIPTION
This PR removes the 'set status' option from document status dropdown and uses the "_ui-select_" dropdown, with the "_allow-clear_" option.

Before:
![before](https://cloud.githubusercontent.com/assets/18520391/18189635/ea4e624a-70bc-11e6-87c0-fe574cf8921c.png)

After:
![pchr-1322](https://cloud.githubusercontent.com/assets/18520391/18189640/ef050c58-70bc-11e6-9eed-90815dda8296.gif)

This PR is related to: https://github.com/civicrm/civihr/pull/1130