### PR TITLE
PCHR-1604 - Update extensions to use hook_civicrm_tabset instead of hook_civicrm_tabs

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -186,7 +186,7 @@ function tasksassignments_civicrm_tabset($tabsetName, &$tabs, $context) {
   if ($tabsetName === 'civicrm/contact/view') {
     CRM_Tasksassignments_Page_Tasksassignments::registerScripts();
     if (CRM_Core_Permission::check('access Tasks and Assignments')) {
-      $tabs[] = Array(
+      $tabs[] = array(
         'id'        => 'civitasks',
         'url'       => CRM_Utils_System::url('civicrm/contact/view/tasks'),
         'title'     => ts('Tasks'),
@@ -196,7 +196,7 @@ function tasksassignments_civicrm_tabset($tabsetName, &$tabs, $context) {
         'fields' => 'documents_tab',
       ));
       if (!empty($documentsTab['values']['documents_tab']['value'])) {
-        $tabs[] = Array(
+        $tabs[] = array(
           'id'        => 'cividocuments',
           'url'       => CRM_Utils_System::url('civicrm/contact/view/documents'),
           'title'     => ts('Documents'),

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -171,35 +171,38 @@ function tasksassignments_civicrm_pageRun($page) {
 }
 
 /**
- * Implementation of hook_civicrm_tabs
- * tasks and documents tabs should appear after assignments tab directly
- * and since assignments tab weight is
- * set to 30 we set both of those to
- * 40 & 50 respectively
+ * Implementation of hook_civicrm_tabset.
+ *
+ * Tasks and documents tabs should appear after Assignments tab directly
+ * and since assignments tab weight is set to 30 we set both of those to
+ * 40 and 50 respectively.
+ *
+ * @param string $tabsetName
+ * @param array &$tabs
+ * @param array $context
  */
 
-function tasksassignments_civicrm_tabs(&$tabs) {
-  CRM_Tasksassignments_Page_Tasksassignments::registerScripts();
-
-  if (CRM_Core_Permission::check('access Tasks and Assignments')) {
-    $tabs[] = Array(
-      'id'        => 'civitasks',
-      'url'       => CRM_Utils_System::url('civicrm/contact/view/tasks'),
-      'title'     => ts('Tasks'),
-      'weight'    => 40
-    );
-
-    $documentsTab = civicrm_api3('TASettings', 'get', array(
-      'fields' => 'documents_tab',
-    ));
-
-    if (!empty($documentsTab['values']['documents_tab']['value'])) {
+function tasksassignments_civicrm_tabset($tabsetName, &$tabs, $context) {
+  if ($tabsetName === 'civicrm/contact/view') {
+    CRM_Tasksassignments_Page_Tasksassignments::registerScripts();
+    if (CRM_Core_Permission::check('access Tasks and Assignments')) {
       $tabs[] = Array(
-        'id'        => 'cividocuments',
-        'url'       => CRM_Utils_System::url('civicrm/contact/view/documents'),
-        'title'     => ts('Documents'),
-        'weight'    => 50
+        'id'        => 'civitasks',
+        'url'       => CRM_Utils_System::url('civicrm/contact/view/tasks'),
+        'title'     => ts('Tasks'),
+        'weight'    => 40,
       );
+      $documentsTab = civicrm_api3('TASettings', 'get', array(
+        'fields' => 'documents_tab',
+      ));
+      if (!empty($documentsTab['values']['documents_tab']['value'])) {
+        $tabs[] = Array(
+          'id'        => 'cividocuments',
+          'url'       => CRM_Utils_System::url('civicrm/contact/view/documents'),
+          'title'     => ts('Documents'),
+          'weight'    => 50,
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
Implementing 'hook_civicrm_tabset' instead of 'hook_civic…rm_tabs' as it's deprecated in CiviCRM 4.7.
