### PR TITLE
PCHR-1630: Apply proper filters

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -40,7 +40,11 @@
                             ng-model="filterParams.ownership"
                             uib-btn-radio="'assigned'">
                             My Docs
-                            <span>({{(listOngoing | filterByOwnership:'assigned').length}})</span>
+                            <span>({{(list |
+                              filterByDue:filterParams.due:filterParams.dateRange |
+                              filterByStatus:filterParams.documentStatus |
+                              filterByOwnership:'assigned').length}})
+                            </span>
                           </a>
                           <a
                             ui-sref="documents.delegated"
@@ -48,7 +52,11 @@
                             ng-model="filterParams.ownership"
                             uib-btn-radio="'delegated'">
                             Delegated Docs
-                            <span>({{(listOngoing | filterByOwnership:'delegated').length}})</span>
+                            <span>({{(list |
+                              filterByDue:filterParams.due:filterParams.dateRange |
+                              filterByStatus:filterParams.documentStatus |
+                              filterByOwnership:'delegated').length}})
+                            </span>
                           </a>
                           <a
                             ui-sref="documents.all"
@@ -56,7 +64,10 @@
                             ng-model="filterParams.ownership"
                             uib-btn-radio="null">
                             All
-                            <span>({{(listOngoing).length}})</span>
+                            <span>({{(list |
+                              filterByDue:filterParams.due:filterParams.dateRange |
+                              filterByStatus:filterParams.documentStatus).length}})
+                            </span>
                           </a>
                         </div>
                     </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -27,7 +27,10 @@
                                   uib-btn-radio="'assigned'">
                                     My Tasks
                                     <span>
-                                      ({{(listOngoing | filterByStatus:cache.taskStatusResolve:false | filterByOwnership:'assigned').length}})
+                                      ({{(list |
+                                      filterByDue:filterParams.due:filterParams.dateRange |
+                                      filterByStatus:cache.taskStatusResolve:false |
+                                      filterByOwnership:'assigned').length}})
                                     </span>
                                 </a>
                                 <a
@@ -37,7 +40,10 @@
                                   uib-btn-radio="'delegated'">
                                     Delegated Tasks
                                     <span>
-                                      ({{(listOngoing | filterByStatus:cache.taskStatusResolve:false | filterByOwnership:'delegated').length}})
+                                      ({{(list |
+                                      filterByDue:filterParams.due:filterParams.dateRange |
+                                      filterByStatus:cache.taskStatusResolve:false |
+                                      filterByOwnership:'delegated').length}})
                                     </span>
                                 </a>
                                 <a
@@ -47,7 +53,9 @@
                                   uib-btn-radio="null">
                                   All
                                   <span>
-                                    ({{(listOngoing | filterByStatus:cache.taskStatusResolve:false).length}})
+                                    ({{(list |
+                                    filterByDue:filterParams.due:filterParams.dateRange |
+                                    filterByStatus:cache.taskStatusResolve:false).length}})
                                   </span>
                                 </a>
                               </div>


### PR DESCRIPTION
**Problem:** 
Task count on tabs are not updated when switched between filters. 
The counters should show the actual number of tasks below it.

**Fix:** 
Applying `filterByDue` and `filterByStatus`to Documents and `filterByDue` to Tasks on the main `list` array to filter.

Before
![t a](https://cloud.githubusercontent.com/assets/5058867/19299918/ccd714be-9074-11e6-8238-d14afd20fc67.gif)

After
![anim](https://cloud.githubusercontent.com/assets/5058867/19302574/4731d69c-9082-11e6-81d0-dcb1d302ff63.gif)
