### PR TITLE
PCHR-1701: Revert CiviHR version

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/info.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/info.xml
@@ -8,8 +8,8 @@
     <author>Mateusz Cieplinski</author>
     <email>mateusz@coldrun.pl</email>
   </maintainer>
-  <releaseDate>2016-11-03</releaseDate>
-  <version>1.6.4</version>
+  <releaseDate>2016-11-08</releaseDate>
+  <version>1.6.3</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
After the 2016-11-03 release, additional fixes had to be added to the 1.6.3 release.
Since this is not a public release yet, it was decided we should move the tag
instead of applying hotfixes. That is why we need to rever the version and
updated the release date here.