### PR TITLE
PCHR-1904: Changing activity URL depending upon contact id permissions.

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -409,7 +409,7 @@ class CRM_Tasksassignments_Reminder {
         if ($reminderKey) {
           $reminderData[$reminderKey][] = array(
             'id' => $activityResult->id,
-            'activityUrl' => CIVICRM_UF_BASEURL . '/civicrm/activity/view?action=view&reset=1&id=' . $activityResult->id . '&cid=' . $contactId . '&context=activity&searchContext=activity',
+            'activityUrl' => self::createActivityURL($contactId, $activityResult->id),
             'typeId' => $activityResult->activity_type_id,
             'type' => self::$_activityOptions['type'][$activityResult->activity_type_id],
             'statusId' => $activityResult->status_id,
@@ -475,6 +475,30 @@ class CRM_Tasksassignments_Reminder {
     }
 
     return FALSE;
+  }
+
+  /**
+   * Check if given Contact ID has access to required permission to create
+   * activityURL.
+   *
+   * @param int $contactId
+   * @return string
+   */
+  public static function createActivityURL($contactId = NULL, $activityResultId = NULL) {
+
+    if ($contactId) {
+      $activityUrl = '';
+      $drupal_user = user_load(_get_uf_match_contact($contactId)['uf_id']);
+
+      if (user_access('access CiviCRM', $drupal_user)) {
+        $activityUrl = CIVICRM_UF_BASEURL . '/civicrm/activity/view?action=view&reset=1&id=' . $activityResultId . '&cid=' . $contactId . '&context=activity&searchContext=activity';
+      }
+      else {
+        $activityUrl = CIVICRM_UF_BASEURL . '/dashboard';
+      }
+      return $activityUrl;
+    }
+    return '';
   }
 
   /**

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -76,8 +76,7 @@ class CRM_Tasksassignments_Reminder {
     $contacts = self::_getContactsWithEmail($contactIds);
 
     foreach ($contacts as $id => $contact) {
-      $url = CIVICRM_UF_BASEURL . '/civicrm/contact/view?reset=1&cid=' . $id;
-
+      $url = self::createContactURL($id);
       $details['ids'][] = $id;
       $details['links'][] = '<a href="' . $url . '" style="color:#42b0cb;font-weight:normal;text-decoration:underline;">' . $contact['display_name'] . '</a>';
       $details['names'][] = $contact['display_name'];
@@ -383,8 +382,7 @@ class CRM_Tasksassignments_Reminder {
         $activityContactRow = explode('|', $activityResult->activity_contact);
         foreach ($activityContactRow as $value) {
           list($type, $cId, $cSortName) = explode(':', $value);
-
-          $contactUrl = CIVICRM_UF_BASEURL . '/civicrm/contact/view?reset=1&cid=' . $cId;
+          $contactUrl = self::createContactURL($cId);
           $activityContact[$type][$cId] = '<a href="' . $contactUrl . '" style="color:#42b0cb;font-weight:normal;text-decoration:underline;">' . $cSortName . '</a>';
         }
 
@@ -497,6 +495,30 @@ class CRM_Tasksassignments_Reminder {
         $activityUrl = CIVICRM_UF_BASEURL . '/dashboard';
       }
       return $activityUrl;
+    }
+    return '';
+  }
+
+   /**
+   * Check if given Contact ID has access to required permission to create
+   * contactURL.
+   *
+   * @param int $contactId
+   * @return string
+   */
+  public static function createContactURL($contactId = NULL) {
+
+    if ($contactId) {
+      $contactUrl = '';
+      $drupal_user = user_load(_get_uf_match_contact($contactId)['uf_id']);
+
+      if (user_access('access CiviCRM', $drupal_user)) {
+        $contactUrl = CIVICRM_UF_BASEURL . '/civicrm/contact/view?reset=1&cid=' . $contactId;
+      }
+      else {
+        $contactUrl = CIVICRM_UF_BASEURL . '/dashboard';
+      }
+      return $contactUrl;
     }
     return '';
   }


### PR DESCRIPTION
**Problem:**
The daily email digest goes out to all creators (civihr_admin) and assignees (could be civihr_admin/civihr_manager/civihr_staff) of tasks/docs that are overdue/due today/coming up this week. Creators see both tasks/docs created and delegated by them. Assignees see only tasks/docs they are supposed to work on.
Need to use different destination urls depending on user having access civicrm permission.

**Solution:**
Check the contact id loading corresponding drupal user for access permission "access CiviCRM" , if it has access than the email link should point to civicrm else it should link to dashboard.