### PR TITLE
PCHR-459: Remove the creation of default activity types

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -156,30 +156,6 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     }
 
     /*
-     * Install Task Types
-     */
-    public function upgrade_0004() {
-
-      $this->_installActivityTypes('CiviTask', array(
-        'Schedule joining date',
-        'Probation appraisal (start probation workflow)',
-        'Group Orientation to organization, values, policies',
-        'Enter employee data in CiviHR',
-        'Issue appointment letter',
-        'Fill Employee Details Form',
-        'Submission of ID/Residence proofs and photos',
-        'Program and work induction by program supervisor',
-        'Schedule Exit Interview',
-        'Conduct Exit Interview',
-        'Get "No Dues" certification',
-        'Revoke Access to Database',
-        'Block work email ID',
-      ));
-
-      return TRUE;
-    }
-
-    /*
      * Install Documents statuses
      */
     public function upgrade_0006() {


### PR DESCRIPTION
Related PR : https://github.com/civicrm/civihr/pull/1276
## Problem
T&A should not create and default activity type , hrcase extension should do that instead .

## Solution

I removed the upgrader that creates these activity types.