### PR TITLE
PCHR-1872: Fix Error on T&A Calendar View

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/DAO/Assignment.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/DAO/Assignment.php
@@ -2,6 +2,14 @@
 
 require_once 'CRM/Core/DAO.php';
 require_once 'CRM/Utils/Type.php';
-class CRM_Tasksassignments_DAO_Assignment extends CRM_Case_BAO_Case
-{
+class CRM_Tasksassignments_DAO_Assignment extends CRM_Case_BAO_Case {
+  public static function fields() {
+    if (!isset(Civi::$statics[__CLASS__]['fields'])) {
+      Civi::$statics[__CLASS__]['fields'] = parent::fields();
+      Civi::$statics[__CLASS__]['fields']['id'] = Civi::$statics[__CLASS__]['fields']['case_id'];
+      unset(Civi::$statics[__CLASS__]['fields']['case_id']);
+    }
+
+    return Civi::$statics[__CLASS__]['fields'];
+  }
 }


### PR DESCRIPTION
## Problem
Expected behaviour for 'get' API call to Assignments entity in front-end required it to return an array of contacts for each assignment found, however, this was not happening. As it turned out, Assignments entity is based on CiviCRM Case entity, and this contact array is only included in results if a case ID is passed as parameter on API call.  However, CiviCRM wasn't able to identify the ID field for the Assignments entity appropriately, expecting it to be either 'id' or 'assignment_id', which never happened, since it was actually 'case_id', as Assignments DAO was a direct extension of Case BAO.

![image-2017-01-12-16-42-09-824](https://cloud.githubusercontent.com/assets/21999940/22978407/96bc72b2-f360-11e6-9354-c77fc5ed3d70.png)


## Solution
Fixed the problem by creating 'id' field in Assignment's DAO, by altering the fields array defined in Case DAO and copying values for 'case_id' and changing its key to 'id'.

![after](https://cloud.githubusercontent.com/assets/21999940/22978430/a370d642-f360-11e6-846b-d6af4f9af902.png)
