### PR TITLE
PCHR-1888: Remove Deleted Contacts' Info From Key Dates

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/KeyDates.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/KeyDates.php
@@ -146,14 +146,20 @@ class CRM_Tasksassignments_KeyDates
         
         if ($tableExists['civicrm_value_jobcontract_dates_13'])
         {
-            $queries[] = "SELECT jcd.entity_id AS contact_id, external_identifier AS contact_external_identifier, c.sort_name AS contact_name, DATE(contract_start_date) AS keydate, 'period_start_date' AS type FROM civicrm_value_jobcontract_dates_13 jcd 
-                LEFT JOIN civicrm_contact c ON jcd.entity_id = c.id 
-                WHERE contract_start_date IS NOT NULL 
+            $queries[] = "
+              SELECT jcd.entity_id AS contact_id, external_identifier AS contact_external_identifier, c.sort_name AS contact_name, DATE(contract_start_date) AS keydate, 'period_start_date' AS type 
+              FROM civicrm_value_jobcontract_dates_13 jcd 
+              LEFT JOIN civicrm_contact c ON jcd.entity_id = c.id 
+              WHERE contract_start_date IS NOT NULL 
+              AND c.is_deleted = 0
             " . self::_buildWhereDateRange('contract_start_date', $startDate, $endDate)
               . self::_buildWhereContactId('entity_id', $contactId);
-            $queries[] = "SELECT jcd.entity_id AS contact_id, external_identifier AS contact_external_identifier, c.sort_name AS contact_name, DATE(contract_end_date) AS keydate, 'period_end_date' AS type FROM civicrm_value_jobcontract_dates_13 jcd 
-                LEFT JOIN civicrm_contact c ON jcd.entity_id = c.id 
-                WHERE contract_end_date IS NOT NULL 
+            $queries[] = "
+              SELECT jcd.entity_id AS contact_id, external_identifier AS contact_external_identifier, c.sort_name AS contact_name, DATE(contract_end_date) AS keydate, 'period_end_date' AS type 
+              FROM civicrm_value_jobcontract_dates_13 jcd 
+              LEFT JOIN civicrm_contact c ON jcd.entity_id = c.id 
+              WHERE contract_end_date IS NOT NULL 
+              AND c.is_deleted = 0
             " . self::_buildWhereDateRange('contract_end_date', $startDate, $endDate)
               . self::_buildWhereContactId('entity_id', $contactId);
         }
@@ -186,6 +192,7 @@ class CRM_Tasksassignments_KeyDates
                       CONCAT( {$sy} ,  '-', DATE_FORMAT(  `birth_date` ,  '%m-%d' ) )
                     ) AS keydate, 'birth_date' as type FROM civicrm_contact
                 WHERE birth_date IS NOT NULL
+                AND is_deleted = 0
             " . self::_buildWhereContactId('id', $contactId);
             
             if (!empty($whereDate))
@@ -201,12 +208,14 @@ class CRM_Tasksassignments_KeyDates
                 SELECT entity_id as contact_id, external_identifier as contact_external_identifier, c.sort_name as contact_name, DATE(initial_join_date_56) as keydate, 'initial_join_date' as type FROM civicrm_value_jobcontract_summary_10 vjs
                 LEFT JOIN civicrm_contact c ON vjs.entity_id = c.id
                 WHERE initial_join_date_56 IS NOT NULL
+                AND c.is_deleted = 0
             " . self::_buildWhereDateRange('initial_join_date_56', $startDate, $endDate)
               . self::_buildWhereContactId('entity_id', $contactId);
             $queries[] = "
                 SELECT entity_id as contact_id, external_identifier as contact_external_identifier, c.sort_name as contact_name, DATE(final_termination_date_57) as keydate, 'final_termination_date' as type FROM civicrm_value_jobcontract_summary_10 vjs
                 LEFT JOIN civicrm_contact c ON vjs.entity_id = c.id
                 WHERE final_termination_date_57 IS NOT NULL
+                AND c.is_deleted = 0
             " . self::_buildWhereDateRange('final_termination_date_57', $startDate, $endDate)
               . self::_buildWhereContactId('entity_id', $contactId);
         }
@@ -216,6 +225,7 @@ class CRM_Tasksassignments_KeyDates
                 SELECT entity_id as contact_id, external_identifier as contact_external_identifier, c.sort_name as contact_name, DATE(probation_end_date) as keydate, 'probation_end_date' as type FROM civicrm_value_probation_12 vp
                 LEFT JOIN civicrm_contact c ON vp.entity_id = c.id
                 WHERE probation_end_date IS NOT NULL
+                AND c.is_deleted = 0
             " . self::_buildWhereDateRange('probation_end_date', $startDate, $endDate)
               . self::_buildWhereContactId('entity_id', $contactId);
         }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -482,7 +482,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
       civicrm_api3('OptionValue', 'create', array(
         'option_group_id' => 'ta_settings',
         'name' => 'days_to_create_a_document_clone',
-        'label' => t('Renewed document creation date offset (days)'),
+        'label' => is_callable('t') ? t('Renewed document creation date offset (days)') : 'Renewed document creation date offset (days)',
         'value' => 0,
       ));
     }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/KeyDates.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/KeyDates.php
@@ -1,0 +1,43 @@
+<?php
+use Civi\Test\HeadlessInterface;
+use Civi\Test\TransactionalInterface;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
+
+/**
+ * Tests for CRM\Tasksassignments\KeyDates Class of Tasks & Assignments extension
+ * 
+ * @group headless
+ */
+class CRM_Tasksassignments_KeyDatesTest extends PHPUnit_Framework_TestCase implements
+  HeadlessInterface,
+  TransactionalInterface {
+  
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->install('uk.co.compucorp.civicrm.hrcore')
+      ->installMe(__DIR__)
+      ->apply();
+  }
+  
+  public function testDatesForDeletedContactsNotInResult() {
+    $contact = ContactFabricator::fabricate(['birth_date' => '1977-06-27']);
+    ContactFabricator::fabricate(['birth_date' => '1978-06-19']);
+    ContactFabricator::fabricate(['birth_date' => '1982-08-16']);
+
+    $query = '
+      UPDATE civicrm_contact
+      SET is_deleted = 1
+      WHERE id = %1
+    ';
+    $params = [1 => [$contact['id'], 'Int']];
+    CRM_Core_DAO::executeQuery($query, $params);
+
+    $keyDates = civicrm_api3('KeyDates', 'get', [
+      'sequential' => 1,
+    ]);
+
+    foreach ($keyDates['values'] as $currentDate) {
+      $this->assertNotEquals($contact['id'], $currentDate['contact_id']);
+    }
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/KeyDates.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/KeyDates.php
@@ -20,24 +20,19 @@ class CRM_Tasksassignments_KeyDatesTest extends PHPUnit_Framework_TestCase imple
   }
   
   public function testDatesForDeletedContactsNotInResult() {
-    $contact = ContactFabricator::fabricate(['birth_date' => '1977-06-27']);
-    ContactFabricator::fabricate(['birth_date' => '1978-06-19']);
-    ContactFabricator::fabricate(['birth_date' => '1982-08-16']);
-
-    $query = '
-      UPDATE civicrm_contact
-      SET is_deleted = 1
-      WHERE id = %1
-    ';
-    $params = [1 => [$contact['id'], 'Int']];
-    CRM_Core_DAO::executeQuery($query, $params);
+    $deletedContact = ContactFabricator::fabricate(['birth_date' => '1977-06-27', 'is_deleted' => 1]);
+    $contacts[] = ContactFabricator::fabricate(['birth_date' => '1978-06-19']);
+    $contacts[] = ContactFabricator::fabricate(['birth_date' => '1982-08-16']);
 
     $keyDates = civicrm_api3('KeyDates', 'get', [
       'sequential' => 1,
     ]);
 
+    $this->assertEquals(sizeof($contacts), $keyDates['count']);
+
+    // Verify deleted contact is not in result
     foreach ($keyDates['values'] as $currentDate) {
-      $this->assertNotEquals($contact['id'], $currentDate['contact_id']);
+      $this->assertNotEquals($currentDate['contact_id'], $deletedContact['id']);
     }
   }
 }


### PR DESCRIPTION
# Problem 
Contacts deleted to trash still appear on key dates. They should not. 

# Solution
API Call to KeyDates Entity 'get' function returned dates associated to contacts in trash can, since the is_deleted field was not taken into account when building the query.  Fixed by adding 'is_deleted = 0' to all queries used to obtain key dates.