### PR TITLE
PCHR-1912: Upgrade ui.select

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/AJAX.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/AJAX.php
@@ -61,7 +61,7 @@ class CRM_Tasksassignments_Page_AJAX {
 
     foreach ($unclosedCases as $caseId => $details) {
       $results[] = array(
-        'id' => $caseId,
+        'id' => "{$caseId}",
         'label' => $details['sort_name'] . ' - ' . $details['case_type'] . ($details['end_date'] ? ' (' . ts('closed') . ')' : ''),
         'label_class' => $details['end_date'] ? 'strikethrough' : '',
         'description' => array($details['case_subject'] . ' (' . $details['case_status'] . ')'),

--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -32,23 +32,28 @@
   /*!
    * ui-select
    * http://github.com/angular-ui/ui-select
-   * Version: 0.11.2 - 2015-03-17T04:08:46.478Z
+   * Version: 0.19.5 - 2016-10-24T23:13:59.551Z
    * License: MIT
    */
   /* Style when highlighting a search. */
   /* Select2 theme */
   /* Mark invalid Select2 */
+  /* Handle up direction Select2 */
   /* Selectize theme */
   /* Helper class to show styles when focus */
   /* Fix input width for Selectize theme */
+  /* Fix line break when there's at least one item selected with the Selectize theme */
   /* Fix dropdown width for Selectize theme */
   /* Mark invalid Selectize */
+  /* Handle up direction Selectize */
   /* Bootstrap theme */
   /* Helper class to show styles when focus */
   /* Fix Bootstrap dropdown position when inside a input-group */
   /* See Scrollable Menu with Bootstrap 3 http://stackoverflow.com/questions/19227496 */
   /* fix hide/show angular animation */
   /* Mark invalid Bootstrap */
+  /* Handle up direction Bootstrap */
+  /* Spinner */
   /*
   @license textAngular
   Author : Austin Anderson
@@ -8955,7 +8960,7 @@ fieldset[disabled]
   box-shadow: 1px 4px 15px 0px rgba(0, 0, 0, 0.1);
 }
 #civitasks .ui-select-highlight, #cividocuments .ui-select-highlight {
-  font-weight: 600;
+  font-weight: bold;
 }
 #civitasks .ui-select-offscreen, #cividocuments .ui-select-offscreen {
   clip: rect(0 0 0 0) !important;
@@ -8969,6 +8974,9 @@ fieldset[disabled]
   outline: 0 !important;
   left: 0px !important;
   top: 0px !important;
+}
+#civitasks .ui-select-choices-row:hover, #cividocuments .ui-select-choices-row:hover {
+  background-color: #f5f5f5;
 }
 #civitasks .ng-dirty.ng-invalid > a.select2-choice, #cividocuments .ng-dirty.ng-invalid > a.select2-choice {
   border-color: #D44950;
@@ -8986,17 +8994,77 @@ fieldset[disabled]
   z-index: 9999;
   /* The z-index Select2 applies to the select2-drop */
 }
+#civitasks .ui-select-container[theme="select2"].direction-up .ui-select-match, #cividocuments .ui-select-container[theme="select2"].direction-up .ui-select-match,
+#civitasks .ui-select-container.select2.direction-up .ui-select-match,
+#cividocuments .ui-select-container.select2.direction-up .ui-select-match {
+  border-radius: 4px;
+  /* FIXME hardcoded value :-/ */
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+#civitasks .ui-select-container[theme="select2"].direction-up .ui-select-dropdown, #cividocuments .ui-select-container[theme="select2"].direction-up .ui-select-dropdown,
+#civitasks .ui-select-container.select2.direction-up .ui-select-dropdown,
+#cividocuments .ui-select-container.select2.direction-up .ui-select-dropdown {
+  border-radius: 4px;
+  /* FIXME hardcoded value :-/ */
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-top-width: 1px;
+  /* FIXME hardcoded value :-/ */
+  border-top-style: solid;
+  box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.25);
+  margin-top: -4px;
+  /* FIXME hardcoded value :-/ */
+}
+#civitasks .ui-select-container[theme="select2"].direction-up .ui-select-dropdown .select2-search, #cividocuments .ui-select-container[theme="select2"].direction-up .ui-select-dropdown .select2-search,
+#civitasks .ui-select-container.select2.direction-up .ui-select-dropdown .select2-search,
+#cividocuments .ui-select-container.select2.direction-up .ui-select-dropdown .select2-search {
+  margin-top: 4px;
+  /* FIXME hardcoded value :-/ */
+}
+#civitasks .ui-select-container[theme="select2"].direction-up.select2-dropdown-open .ui-select-match, #cividocuments .ui-select-container[theme="select2"].direction-up.select2-dropdown-open .ui-select-match,
+#civitasks .ui-select-container.select2.direction-up.select2-dropdown-open .ui-select-match,
+#cividocuments .ui-select-container.select2.direction-up.select2-dropdown-open .ui-select-match {
+  border-bottom-color: #5897fb;
+}
+#civitasks .ui-select-container[theme="select2"] .ui-select-dropdown .ui-select-search-hidden, #cividocuments .ui-select-container[theme="select2"] .ui-select-dropdown .ui-select-search-hidden,
+#civitasks .ui-select-container[theme="select2"] .ui-select-dropdown .ui-select-search-hidden input,
+#cividocuments .ui-select-container[theme="select2"] .ui-select-dropdown .ui-select-search-hidden input {
+  opacity: 0;
+  height: 0;
+  min-height: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
 #civitasks .selectize-input.selectize-focus, #cividocuments .selectize-input.selectize-focus {
   border-color: #007FBB !important;
 }
-#civitasks .selectize-control > .selectize-input > input, #cividocuments .selectize-control > .selectize-input > input {
+#civitasks .selectize-control.single > .selectize-input > input, #cividocuments .selectize-control.single > .selectize-input > input {
   width: 100%;
+}
+#civitasks .selectize-control.multi > .selectize-input > input, #cividocuments .selectize-control.multi > .selectize-input > input {
+  margin: 0 !important;
 }
 #civitasks .selectize-control > .selectize-dropdown, #cividocuments .selectize-control > .selectize-dropdown {
   width: 100%;
 }
 #civitasks .ng-dirty.ng-invalid > div.selectize-input, #cividocuments .ng-dirty.ng-invalid > div.selectize-input {
   border-color: #D44950;
+}
+#civitasks .ui-select-container[theme="selectize"].direction-up .ui-select-dropdown, #cividocuments .ui-select-container[theme="selectize"].direction-up .ui-select-dropdown {
+  box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.25);
+  margin-top: -2px;
+  /* FIXME hardcoded value :-/ */
+}
+#civitasks .ui-select-container[theme="selectize"] input.ui-select-search-hidden, #cividocuments .ui-select-container[theme="selectize"] input.ui-select-search-hidden {
+  opacity: 0;
+  height: 0;
+  min-height: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  width: 0;
 }
 #civitasks .btn-default-focus, #cividocuments .btn-default-focus {
   color: #333;
@@ -9022,10 +9090,24 @@ fieldset[disabled]
   position: static;
 }
 #civitasks .input-group > .ui-select-bootstrap > input.ui-select-search.form-control, #cividocuments .input-group > .ui-select-bootstrap > input.ui-select-search.form-control {
-  border-radius: 0;
+  border-radius: 4px;
   /* FIXME hardcoded value :-/ */
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+}
+#civitasks .input-group > .ui-select-bootstrap > input.ui-select-search.form-control.direction-up, #cividocuments .input-group > .ui-select-bootstrap > input.ui-select-search.form-control.direction-up {
+  border-radius: 4px !important;
+  /* FIXME hardcoded value :-/ */
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+#civitasks .ui-select-bootstrap .ui-select-search-hidden, #cividocuments .ui-select-bootstrap .ui-select-search-hidden {
+  opacity: 0;
+  height: 0;
+  min-height: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
 }
 #civitasks .ui-select-bootstrap > .ui-select-match > .btn, #cividocuments .ui-select-bootstrap > .ui-select-match > .btn {
   /* Instead of center because of .btn */
@@ -9036,13 +9118,12 @@ fieldset[disabled]
   top: 45%;
   right: 15px;
 }
-#civitasks .ui-select-bootstrap > .ui-select-choices, #cividocuments .ui-select-bootstrap > .ui-select-choices {
+#civitasks .ui-select-bootstrap > .ui-select-choices, #cividocuments .ui-select-bootstrap > .ui-select-choices, #civitasks .ui-select-bootstrap > .ui-select-no-choice, #cividocuments .ui-select-bootstrap > .ui-select-no-choice {
   width: 100%;
   height: auto;
   max-height: 200px;
   overflow-x: hidden;
   margin-top: -1px;
-  z-index: 1500;
 }
 #civitasks body > .ui-select-bootstrap.open, #cividocuments body > .ui-select-bootstrap.open {
   z-index: 1000;
@@ -9071,7 +9152,10 @@ fieldset[disabled]
 #civitasks .ui-select-multiple .ui-select-match-item, #cividocuments .ui-select-multiple .ui-select-match-item {
   position: relative;
 }
-#civitasks .ui-select-multiple .ui-select-match-item.dropping-before:before, #cividocuments .ui-select-multiple .ui-select-match-item.dropping-before:before {
+#civitasks .ui-select-multiple .ui-select-match-item.dropping .ui-select-match-close, #cividocuments .ui-select-multiple .ui-select-match-item.dropping .ui-select-match-close {
+  pointer-events: none;
+}
+#civitasks .ui-select-multiple:hover .ui-select-match-item.dropping-before:before, #cividocuments .ui-select-multiple:hover .ui-select-match-item.dropping-before:before {
   content: "";
   position: absolute;
   top: 0;
@@ -9080,7 +9164,7 @@ fieldset[disabled]
   margin-right: 2px;
   border-left: 1px solid #428bca;
 }
-#civitasks .ui-select-multiple .ui-select-match-item.dropping-after:after, #cividocuments .ui-select-multiple .ui-select-match-item.dropping-after:after {
+#civitasks .ui-select-multiple:hover .ui-select-match-item.dropping-after:after, #cividocuments .ui-select-multiple:hover .ui-select-match-item.dropping-after:after {
   content: "";
   position: absolute;
   top: 0;
@@ -9089,7 +9173,8 @@ fieldset[disabled]
   margin-left: 2px;
   border-right: 1px solid #428bca;
 }
-#civitasks .ui-select-bootstrap .ui-select-choices-row > a, #cividocuments .ui-select-bootstrap .ui-select-choices-row > a {
+#civitasks .ui-select-bootstrap .ui-select-choices-row > span, #cividocuments .ui-select-bootstrap .ui-select-choices-row > span {
+  cursor: pointer;
   display: block;
   padding: 3px 20px;
   clear: both;
@@ -9098,20 +9183,20 @@ fieldset[disabled]
   color: #333;
   white-space: nowrap;
 }
-#civitasks .ui-select-bootstrap .ui-select-choices-row > a:hover, #cividocuments .ui-select-bootstrap .ui-select-choices-row > a:hover, #civitasks .ui-select-bootstrap .ui-select-choices-row > a:focus, #cividocuments .ui-select-bootstrap .ui-select-choices-row > a:focus {
+#civitasks .ui-select-bootstrap .ui-select-choices-row > span:hover, #cividocuments .ui-select-bootstrap .ui-select-choices-row > span:hover, #civitasks .ui-select-bootstrap .ui-select-choices-row > span:focus, #cividocuments .ui-select-bootstrap .ui-select-choices-row > span:focus {
   text-decoration: none;
   color: #262626;
   background-color: #f5f5f5;
 }
-#civitasks .ui-select-bootstrap .ui-select-choices-row.active > a, #cividocuments .ui-select-bootstrap .ui-select-choices-row.active > a {
+#civitasks .ui-select-bootstrap .ui-select-choices-row.active > span, #cividocuments .ui-select-bootstrap .ui-select-choices-row.active > span {
   color: #fff;
   text-decoration: none;
   outline: 0;
   background-color: #428bca;
 }
-#civitasks .ui-select-bootstrap .ui-select-choices-row.disabled > a, #cividocuments .ui-select-bootstrap .ui-select-choices-row.disabled > a,
-#civitasks .ui-select-bootstrap .ui-select-choices-row.active.disabled > a,
-#cividocuments .ui-select-bootstrap .ui-select-choices-row.active.disabled > a {
+#civitasks .ui-select-bootstrap .ui-select-choices-row.disabled > span, #cividocuments .ui-select-bootstrap .ui-select-choices-row.disabled > span,
+#civitasks .ui-select-bootstrap .ui-select-choices-row.active.disabled > span,
+#cividocuments .ui-select-bootstrap .ui-select-choices-row.active.disabled > span {
   color: #777;
   cursor: not-allowed;
   background-color: #fff;
@@ -9123,6 +9208,63 @@ fieldset[disabled]
 }
 #civitasks .ui-select-bootstrap.ng-dirty.ng-invalid > button.btn.ui-select-match, #cividocuments .ui-select-bootstrap.ng-dirty.ng-invalid > button.btn.ui-select-match {
   border-color: #D44950;
+}
+#civitasks .ui-select-container[theme="bootstrap"].direction-up .ui-select-dropdown, #cividocuments .ui-select-container[theme="bootstrap"].direction-up .ui-select-dropdown {
+  box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.25);
+}
+#civitasks .ui-select-bootstrap .ui-select-match-text, #cividocuments .ui-select-bootstrap .ui-select-match-text {
+  width: 100%;
+  padding-right: 1em;
+}
+#civitasks .ui-select-bootstrap .ui-select-match-text span, #cividocuments .ui-select-bootstrap .ui-select-match-text span {
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+}
+#civitasks .ui-select-bootstrap .ui-select-toggle > a.btn, #cividocuments .ui-select-bootstrap .ui-select-toggle > a.btn {
+  position: absolute;
+  height: 10px;
+  right: 10px;
+  margin-top: -2px;
+}
+#civitasks .ui-select-refreshing, #cividocuments .ui-select-refreshing {
+  position: absolute;
+  right: 0;
+  padding: 8px 27px;
+  top: 1px;
+  display: inline-block;
+  font-family: 'Glyphicons Halflings';
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+}
+@-webkit-keyframes ui-select-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+@keyframes ui-select-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+#civitasks .ui-select-spin, #cividocuments .ui-select-spin {
+  -webkit-animation: ui-select-spin 2s infinite linear;
+  animation: ui-select-spin 2s infinite linear;
+}
+#civitasks .ui-select-refreshing.ng-animate, #cividocuments .ui-select-refreshing.ng-animate {
+  -webkit-animation: none 0s;
 }
 #civitasks .ta-hidden-input, #cividocuments .ta-hidden-input {
   width: 1px;
@@ -11359,7 +11501,7 @@ fieldset[disabled]
   /* using this override until we have a separate directive for that */
 }
 #civitasks form.form-task .modal-header .close, #cividocuments form.form-task .modal-header .close, #civitasks form.form-document .modal-header .close, #cividocuments form.form-document .modal-header .close {
-  margin-top: 7px;
+  margin-top: 5px;
   margin-left: -3px;
 }
 #civitasks form.form-task .modal-header > *[class^='col-'], #cividocuments form.form-task .modal-header > *[class^='col-'], #civitasks form.form-document .modal-header > *[class^='col-'], #cividocuments form.form-document .modal-header > *[class^='col-'] {

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/modules/_select.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/modules/_select.scss
@@ -1,14 +1,14 @@
 /*!
  * ui-select
  * http://github.com/angular-ui/ui-select
- * Version: 0.11.2 - 2015-03-17T04:08:46.478Z
+ * Version: 0.19.5 - 2016-10-24T23:13:59.551Z
  * License: MIT
  */
 
 
 /* Style when highlighting a search. */
 .ui-select-highlight {
-  font-weight: 600;
+  font-weight: bold;
 }
 
 .ui-select-offscreen {
@@ -25,11 +25,16 @@
   top: 0px !important;
 }
 
+
+.ui-select-choices-row:hover {
+  background-color: #f5f5f5;
+}
+
 /* Select2 theme */
 
 /* Mark invalid Select2 */
 .ng-dirty.ng-invalid > a.select2-choice {
-  border-color: #D44950;
+    border-color: #D44950;
 }
 
 .select2-result-single {
@@ -41,11 +46,50 @@
 }
 
 .select-locked > .ui-select-match-close{
-  display:none;
+    display:none;
 }
 
 body > .select2-container.open {
   z-index: 9999; /* The z-index Select2 applies to the select2-drop */
+}
+
+/* Handle up direction Select2 */
+.ui-select-container[theme="select2"].direction-up .ui-select-match,
+.ui-select-container.select2.direction-up .ui-select-match {
+    border-radius: 4px; /* FIXME hardcoded value :-/ */
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+.ui-select-container[theme="select2"].direction-up .ui-select-dropdown,
+.ui-select-container.select2.direction-up .ui-select-dropdown {
+    border-radius: 4px; /* FIXME hardcoded value :-/ */
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+
+    border-top-width: 1px;  /* FIXME hardcoded value :-/ */
+    border-top-style: solid;
+
+    box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.25);
+
+    margin-top: -4px; /* FIXME hardcoded value :-/ */
+}
+.ui-select-container[theme="select2"].direction-up .ui-select-dropdown .select2-search,
+.ui-select-container.select2.direction-up .ui-select-dropdown .select2-search {
+    margin-top: 4px; /* FIXME hardcoded value :-/ */
+}
+.ui-select-container[theme="select2"].direction-up.select2-dropdown-open .ui-select-match,
+.ui-select-container.select2.direction-up.select2-dropdown-open .ui-select-match {
+    border-bottom-color: #5897fb;
+}
+
+.ui-select-container[theme="select2"] .ui-select-dropdown .ui-select-search-hidden,
+.ui-select-container[theme="select2"] .ui-select-dropdown .ui-select-search-hidden input{
+    opacity: 0;
+    height: 0;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    border:0;
 }
 
 /* Selectize theme */
@@ -56,8 +100,13 @@ body > .select2-container.open {
 }
 
 /* Fix input width for Selectize theme */
-.selectize-control > .selectize-input > input {
+.selectize-control.single > .selectize-input > input {
   width: 100%;
+}
+
+/* Fix line break when there's at least one item selected with the Selectize theme */
+.selectize-control.multi > .selectize-input > input {
+  margin: 0 !important;
 }
 
 /* Fix dropdown width for Selectize theme */
@@ -67,9 +116,24 @@ body > .select2-container.open {
 
 /* Mark invalid Selectize */
 .ng-dirty.ng-invalid > div.selectize-input {
-  border-color: #D44950;
+    border-color: #D44950;
 }
 
+/* Handle up direction Selectize */
+.ui-select-container[theme="selectize"].direction-up .ui-select-dropdown {
+    box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.25);
+    margin-top: -2px; /* FIXME hardcoded value :-/ */
+}
+
+.ui-select-container[theme="selectize"] input.ui-select-search-hidden{
+    opacity: 0;
+    height: 0;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    border:0;
+    width: 0;
+}
 
 /* Bootstrap theme */
 
@@ -103,9 +167,23 @@ body > .select2-container.open {
 }
 
 .input-group > .ui-select-bootstrap > input.ui-select-search.form-control {
-  border-radius: $border-radius-base; /* FIXME hardcoded value :-/ */
+  border-radius: 4px; /* FIXME hardcoded value :-/ */
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+}
+.input-group > .ui-select-bootstrap > input.ui-select-search.form-control.direction-up {
+  border-radius: 4px !important; /* FIXME hardcoded value :-/ */
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.ui-select-bootstrap .ui-select-search-hidden{
+    opacity: 0;
+    height: 0;
+    min-height: 0;
+    padding: 0;
+    margin: 0;
+    border:0;
 }
 
 .ui-select-bootstrap > .ui-select-match > .btn{
@@ -120,13 +198,12 @@ body > .select2-container.open {
 }
 
 /* See Scrollable Menu with Bootstrap 3 http://stackoverflow.com/questions/19227496 */
-.ui-select-bootstrap > .ui-select-choices {
+.ui-select-bootstrap > .ui-select-choices ,.ui-select-bootstrap > .ui-select-no-choice {
   width: 100%;
   height: auto;
   max-height: 200px;
   overflow-x: hidden;
   margin-top: -1px;
-  z-index: 1500;
 }
 
 body > .ui-select-bootstrap.open {
@@ -160,7 +237,11 @@ body > .ui-select-bootstrap.open {
   position: relative;
 }
 
-.ui-select-multiple .ui-select-match-item.dropping-before:before {
+.ui-select-multiple .ui-select-match-item.dropping .ui-select-match-close {
+  pointer-events: none;
+}
+
+.ui-select-multiple:hover .ui-select-match-item.dropping-before:before {
   content: "";
   position: absolute;
   top: 0;
@@ -170,7 +251,7 @@ body > .ui-select-bootstrap.open {
   border-left: 1px solid #428bca;
 }
 
-.ui-select-multiple .ui-select-match-item.dropping-after:after {
+.ui-select-multiple:hover .ui-select-match-item.dropping-after:after {
   content: "";
   position: absolute;
   top: 0;
@@ -180,43 +261,109 @@ body > .ui-select-bootstrap.open {
   border-right: 1px solid #428bca;
 }
 
-.ui-select-bootstrap .ui-select-choices-row>a {
-  display: block;
-  padding: 3px 20px;
-  clear: both;
-  font-weight: 400;
-  line-height: 1.42857143;
-  color: #333;
-  white-space: nowrap;
+.ui-select-bootstrap .ui-select-choices-row>span {
+    cursor: pointer;
+    display: block;
+    padding: 3px 20px;
+    clear: both;
+    font-weight: 400;
+    line-height: 1.42857143;
+    color: #333;
+    white-space: nowrap;
 }
 
-.ui-select-bootstrap .ui-select-choices-row>a:hover, .ui-select-bootstrap .ui-select-choices-row>a:focus {
-  text-decoration: none;
-  color: #262626;
-  background-color: #f5f5f5;
+.ui-select-bootstrap .ui-select-choices-row>span:hover, .ui-select-bootstrap .ui-select-choices-row>span:focus {
+    text-decoration: none;
+    color: #262626;
+    background-color: #f5f5f5;
 }
 
-.ui-select-bootstrap .ui-select-choices-row.active>a {
-  color: #fff;
-  text-decoration: none;
-  outline: 0;
-  background-color: #428bca;
+.ui-select-bootstrap .ui-select-choices-row.active>span {
+    color: #fff;
+    text-decoration: none;
+    outline: 0;
+    background-color: #428bca;
 }
 
-.ui-select-bootstrap .ui-select-choices-row.disabled>a,
-.ui-select-bootstrap .ui-select-choices-row.active.disabled>a {
-  color: #777;
-  cursor: not-allowed;
-  background-color: #fff;
+.ui-select-bootstrap .ui-select-choices-row.disabled>span,
+.ui-select-bootstrap .ui-select-choices-row.active.disabled>span {
+    color: #777;
+    cursor: not-allowed;
+    background-color: #fff;
 }
 
 /* fix hide/show angular animation */
 .ui-select-match.ng-hide-add,
 .ui-select-search.ng-hide-add {
-  display: none !important;
+    display: none !important;
 }
 
 /* Mark invalid Bootstrap */
 .ui-select-bootstrap.ng-dirty.ng-invalid > button.btn.ui-select-match {
-  border-color: #D44950;
+    border-color: #D44950;
+}
+
+/* Handle up direction Bootstrap */
+.ui-select-container[theme="bootstrap"].direction-up .ui-select-dropdown {
+    box-shadow: 0 -4px 8px rgba(0, 0, 0, 0.25);
+}
+
+.ui-select-bootstrap .ui-select-match-text {
+    width: 100%;
+    padding-right: 1em;
+}
+.ui-select-bootstrap .ui-select-match-text span {
+    display: inline-block;
+    width: 100%;
+    overflow: hidden;
+}
+.ui-select-bootstrap .ui-select-toggle > a.btn {
+  position: absolute;
+  height: 10px;
+  right: 10px;
+  margin-top: -2px;
+}
+
+/* Spinner */
+.ui-select-refreshing {
+    position: absolute;
+    right: 0;
+    padding: 8px 27px;
+    top: 1px;
+    display: inline-block;
+    font-family: 'Glyphicons Halflings';
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1;
+    -webkit-font-smoothing:antialiased;
+ }
+
+@-webkit-keyframes ui-select-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+@keyframes ui-select-spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+.ui-select-spin {
+  -webkit-animation: ui-select-spin 2s infinite linear;
+  animation: ui-select-spin 2s infinite linear;
+}
+
+.ui-select-refreshing.ng-animate {
+  -webkit-animation: none 0s;
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -86,6 +86,7 @@
             </div>
             Assigned to: <span
                 editable-ui-select="task.assignee_contact_id[0]"
+                theme="civihr-ui-select"
                 e-required="true"
                 ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.assignee_contact_id[0]].id}}"
                 onshow="updateContacts(cache.contact.arrSearch);"
@@ -127,6 +128,7 @@
             <span class="{{prefix}}assignment-type">
                 <span
                         editable-ui-select="task.case_id"
+                        theme="civihr-ui-select"
                         onshow="updateAssignments(cache.assignment.arrSearch, task.target_contact_id[0]);"
                         onbeforesave="updateTask(task, { case_id: $data });"
                         on-select="cacheAssignment($item);">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -84,24 +84,23 @@
                             <div class="form-group">
                                 <label class="col-xs-12 col-sm-2 control-label">Contact:</label>
                                 <div class="col-xs-12 col-sm-10">
-                                    <div class="input-group">
-                                        <ui-select
-                                                allow-clear
-                                                ng-model="filterParams.contactId">
-                                            <ui-select-match class="ui-select-match"
-                                                    placeholder="Search / Filter">{{$select.selected.label}}</ui-select-match>
-                                            <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
-                                                                refresh-delay="0">
-                                                <div ng-bind="contact.label"></div>
-                                                <small ng-bind="contact.description[0]"></small>
-                                            </ui-select-choices>
-                                        </ui-select>
-                                        <span class="input-group-btn">
-                                          <a ng-click="filterParams.contactId = ''" class="btn btn-default">
-                                              <span class="fa fa-remove"></span>
-                                          </a>
-                                        </span>
-                                    </div>
+                                  <ui-select
+                                    theme="civihr-ui-select"
+                                    ng-model="filterParams.contactId">
+                                    <ui-select-match
+                                      allow-clear
+                                      class="ui-select-match"
+                                      placeholder="Search / Filter">
+                                      {{$select.selected.label}}
+                                    </ui-select-match>
+                                    <ui-select-choices
+                                      class="ui-select-choices"
+                                      repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
+                                      refresh-delay="0">
+                                      <div ng-bind="contact.label"></div>
+                                      <small ng-bind="contact.description[0]"></small>
+                                    </ui-select-choices>
+                                  </ui-select>
                                 </div>
                             </div>
                         </div>
@@ -109,14 +108,17 @@
                             <div class="form-group">
                                 <label class="col-xs-12 col-sm-4 control-label">Assignment Type:</label>
                                 <div class="col-xs-12 col-sm-8">
-                                    <ui-select
-                                            multiple
-                                            ng-model="filterParams.assignmentType">
-                                        <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
-                                        <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
-                                            <div ng-bind-html="type.title | highlight: $select.search"></div>
-                                        </ui-select-choices>
-                                    </ui-select>
+                                  <ui-select
+                                    theme="civihr-ui-select"
+                                    multiple
+                                    ng-model="filterParams.assignmentType">
+                                    <ui-select-match class="ui-select-match" placeholder="Select assignment...">
+                                      {{$item.title}}
+                                    </ui-select-match>
+                                    <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
+                                      <div ng-bind-html="type.title | highlight: $select.search"></div>
+                                    </ui-select-choices>
+                                  </ui-select>
                                 </div>
                             </div>
                         </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -189,6 +189,7 @@
             </div>
             Target:
             <span editable-ui-select="task.target_contact_id[0]"
+                  theme="civihr-ui-select"
                   e-required="true"
                   ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.target_contact_id[0]].id}}"
                   onbeforesave="cacheContact($data) && updateTask(task, { target_contact_id: [$data] })"
@@ -233,6 +234,7 @@
             Assigned to:
             <span editable-ui-select="task.assignee_contact_id[0]"
                   e-required="true"
+                  theme="civihr-ui-select"
                   ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.assignee_contact_id[0]].id}}"
                   onshow="updateContacts(cache.contact.arrSearch);"
                   onbeforesave="cacheContact($data) && updateTask(task, { assignee_contact_id: [$data] });">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -75,29 +75,21 @@
                             <div class="row form-horizontal">
                                 <div class="col-xs-6">
                                     <div class="form-group">
-                                        <label class="col-xs-12 col-sm-2 control-label">Contact:</label>
-
-                                        <div class="col-xs-12 col-sm-10">
-                                            <div class="input-group">
-                                                <ui-select allow-clear ng-model="filterParams.contactId">
-                                                    <ui-select-match class="ui-select-match" placeholder="Search / Filter">
-                                                        {{$select.selected.label}}
-                                                    </ui-select-match>
-                                                    <ui-select-choices
-                                                            class="ui-select-choices"
-                                                            repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
-                                                            refresh-delay="0">
-                                                        <div ng-bind="contact.label"></div>
-                                                        <small ng-bind="contact.description[0]"></small>
-                                                    </ui-select-choices>
-                                                </ui-select>
-                                                <span class="input-group-btn">
-                                                  <a ng-click="filterParams.contactId = ''" class="btn btn-default">
-                                                      <span class="fa fa-remove"></span>
-                                                  </a>
-                                                </span>
-                                            </div>
-                                        </div>
+                                      <label class="col-xs-12 col-sm-2 control-label">Contact:</label>
+                                      <div class="col-xs-12 col-sm-10">
+                                        <ui-select  ng-model="filterParams.contactId" theme="civihr-ui-select">
+                                          <ui-select-match allow-clear class="ui-select-match" placeholder="Search / Filter">
+                                            {{$select.selected.label}}
+                                          </ui-select-match>
+                                          <ui-select-choices
+                                            class="ui-select-choices"
+                                            repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
+                                            refresh-delay="0">
+                                            <div ng-bind="contact.label"></div>
+                                            <small ng-bind="contact.description[0]"></small>
+                                          </ui-select-choices>
+                                        </ui-select>
+                                      </div>
                                     </div>
                                 </div>
                                 <div class="col-xs-6">
@@ -105,7 +97,7 @@
                                         <label class="col-xs-12 col-sm-4 control-label">Assignment Type:</label>
 
                                         <div class="col-xs-12 col-sm-8">
-                                            <ui-select multiple ng-model="filterParams.assignmentType">
+                                            <ui-select multiple ng-model="filterParams.assignmentType" theme="civihr-ui-select">
                                                 <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}
                                                 </ui-select-match>
                                                 <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -11,7 +11,7 @@
       <!-- Search and select by name and email -->
       <div class="row">
         <div class="col-xs-12">
-          <ui-select name="target" ng-class="{'has-error': documentForm.target.$invalid}" allow-clear class="required-field-indicator" ng-model="document.target_contact_id[0]" on-select="cacheContact($item)" ng-required="true">
+          <ui-select name="target" theme="civihr-ui-select" allow-clear class="required-field-indicator" ng-model="document.target_contact_id[0]" on-select="cacheContact($item)" ng-required="true">
             <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">
               {{$select.selected.label}}
             </ui-select-match>
@@ -132,7 +132,7 @@
           </span>
         </div>
         <div class="col-xs-12 col-sm-5" ng-show="showAssignmentField">
-          <ui-select allow-clear ng-model="document.case_id" on-select="cacheAssignment($item);">
+          <ui-select theme="civihr-ui-select" allow-clear ng-model="document.case_id" on-select="cacheAssignment($item);">
             <ui-select-match class="ui-select-match" placeholder="Enter search term...">{{$select.selected.label}}
             </ui-select-match>
             <ui-select-choices class="ui-select-choices" repeat="assignment.id as assignment in assignments" refresh="refreshAssignments($select.search)" refresh-delay="0">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
@@ -11,7 +11,7 @@
       <!--  Select Target Contact-->
       <div class="row">
         <div class="col-xs-12">
-          <ui-select ng-if="showCId" allow-clear name="target" ng-class="{'has-error': taskForm.target.$invalid}" ng-model="task.target_contact_id[0]" on-select="cacheContact($item)" ng-required="true" class="required-field-indicator">
+          <ui-select theme="civihr-ui-select" ng-if="showCId" allow-clear name="target" ng-model="task.target_contact_id[0]" on-select="cacheContact($item)" ng-required="true" class="required-field-indicator">
             <ui-select-match class="ui-select-match" placeholder="Select Target Contact">
               {{$select.selected.label}}
             </ui-select-match>


### PR DESCRIPTION
_(Related to https://github.com/civicrm/civihr/pull/1592)_

This PR has changes related to the upgrade of the `ui.select` library

### Force assignment id to be a string
The assignment lookup dropdown is fetching the data from a backend endpoint, which was returning the id of the assignment as a number, not as a string. This caused a problem with the newer version of ui-select, as the dropdown was using the id as a string to find the currently selected assignment in the assignments list. Forcing the id to be a string solves the issue
```php
foreach ($unclosedCases as $caseId => $details) {
  $results[] = array(
    'id' => "{$caseId}",
```

### Update local ui-select css
The T&A is not yet using the common theme, and as such it has a local copy of the ui-select css. Given that the library has been updated, the css needs to be updated as well

### Implementing civihr-ui-select theme
We have a custom theme (`civihr-ui-select`) for the ui-select dropdown, but the theme was not consistently applied in the T&A extension. This PR fixes it

#### Target dropdown
<img width="400" alt="after-target-contact" src="https://cloud.githubusercontent.com/assets/6400898/23741025/ac9d4eec-04a6-11e7-8a81-59a1a6764f44.png">

#### Edit in place
<img width="400" alt="after-edit-in-place" src="https://cloud.githubusercontent.com/assets/6400898/23741030/b4465d5a-04a6-11e7-844f-fdc4f39768ef.png">

#### Filters
<img width="500" alt="after-filters-doc" src="https://cloud.githubusercontent.com/assets/6400898/23741034/bbe306b2-04a6-11e7-83b5-a90ca706ac7b.png">
<img width="500" alt="after-filters" src="https://cloud.githubusercontent.com/assets/6400898/23741035/bbe7d480-04a6-11e7-8029-de0a2c5571c2.png">

#### Document modal
<img width="500" alt="after-doc-modal" src="https://cloud.githubusercontent.com/assets/6400898/23741037/c2695f04-04a6-11e7-911b-45ef073c7b64.png">


