### PR TITLE
PCHR-1908: Fix dates fields width in task/document modal

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -42,8 +42,8 @@
         <!-- Due Date -->
         <div class="col-xs-6">
           <div class="form-group">
-            <label for="{{prefix}}document-due" class="col-xs-4 text-nowrap control-label required-field-indicator">Due Date:</label>
-            <div class="col-xs-8 input-group input-group-unstyled" ng-class="{'has-error': documentForm.dueDate.$invalid}">
+            <label for="{{prefix}}document-due" class="col-xs-3 text-nowrap control-label required-field-indicator">Due:</label>
+            <div class="col-xs-9 input-group input-group-unstyled" ng-class="{'has-error': documentForm.dueDate.$invalid}">
               <input name="dueDate" type="text" id="{{prefix}}document-due" class="form-control" name="documentDue" ng-model="document.activity_date_time" placeholder="dd/mm/yyyy" uib-datepicker-popup ng-required="true" is-open="dpOpened.due" ng-click="dpOpen($event, 'due')">
               <span class="input-group-addon fa fa-calendar"></span>
             </div>
@@ -52,10 +52,10 @@
         <!-- Expires -->
         <div class="col-xs-6">
           <div class="form-group">
-            <label for="{{prefix}}document-exp" class="col-xs-4 control-label no-gutter">
-              <span class="pull-right">Expiry Date:</span>
+            <label for="{{prefix}}document-exp" class="col-xs-3 control-label no-gutter">
+              <span class="pull-right">Expiry:</span>
             </label>
-            <div class="col-xs-8 input-group">
+            <div class="col-xs-9 input-group">
               <input type="text" class="form-control" id="{{prefix}}document-exp" name="documentExpireDate" ng-model="document.expire_date" placeholder="dd/mm/yyyy" uib-datepicker-popup is-open="dpOpened.exp" ng-click="dpOpen($event, 'exp')">
               <span class="input-group-addon fa fa-calendar"></span>
             </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
@@ -47,10 +47,10 @@
         </div>
         <div class="col-xs-12 col-sm-6">
           <div class="input-group form-group">
-            <label class="control-label no-gutter col-sm-4" for="{{prefix}}task-due">
-              <span class="pull-right required-field-indicator">Due Date:</span>
+            <label class="control-label no-gutter col-sm-3" for="{{prefix}}task-due">
+              <span class="pull-right required-field-indicator">Due:</span>
             </label>
-            <div class="col-xs-8 input-group input-group-unstyled" ng-class="{'has-error': taskForm.assignmentDue.$invalid}">
+            <div class="col-xs-9 input-group input-group-unstyled" ng-class="{'has-error': taskForm.assignmentDue.$invalid}">
               <input type="text" name="assignmentDue" id="{{prefix}}task-due" class="form-control" ng-model="task.activity_date_time" placeholder="{{ format }}" ng-required="true" uib-datepicker-popup is-open="dpOpened" ng-click="dpOpen($event);">
               <span class="input-group-addon fa fa-calendar"></span>
             </div>


### PR DESCRIPTION
# Problem
The Due Date and Expity Date fields were not wide enough, resulting in the date value being trimmed

<img width="400" alt="before-document" src="https://cloud.githubusercontent.com/assets/6400898/23787732/b16b2b74-0573-11e7-9f33-f0627669a6f4.png">
<img width="400" alt="before-task" src="https://cloud.githubusercontent.com/assets/6400898/23787731/b15a4dcc-0573-11e7-8a8e-05fb5eeae11a.png">


# Solution
Shortening the label and adjusting the grid cells solved the problem

<img width="400" alt="after-document" src="https://cloud.githubusercontent.com/assets/6400898/23787738/b6d4eeba-0573-11e7-9ad3-d9f2485341fb.png">
<img width="400" alt="after-task" src="https://cloud.githubusercontent.com/assets/6400898/23787750/c28458cc-0573-11e7-96b6-1b596249cf72.png">

