### PR TITLE
PCHR-1911: Placeholders colors in new task and assignment modal

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -9810,7 +9810,7 @@ fieldset[disabled]
   text-transform: none;
 }
 #civitasks .ui-select-match-text, #cividocuments .ui-select-match-text {
-  color: #586277;
+  color: #586277 !important;
 }
 #civitasks .ui-select-toggle[disabled], #cividocuments .ui-select-toggle[disabled] {
   background-color: #f4f7f8;
@@ -11391,7 +11391,7 @@ fieldset[disabled]
 #cividocuments form.form-task .modal-header .ui-select-container .ui-select-toggle .ui-select-match-text, #civitasks form.form-document .modal-header .ui-select-container .ui-select-toggle .ui-select-placeholder, #cividocuments form.form-document .modal-header .ui-select-container .ui-select-toggle .ui-select-placeholder,
 #civitasks form.form-document .modal-header .ui-select-container .ui-select-toggle .ui-select-match-text,
 #cividocuments form.form-document .modal-header .ui-select-container .ui-select-toggle .ui-select-match-text {
-  color: #41afcb !important;
+  color: #586277 !important;
   font-size: 20px !important;
 }
 #civitasks form.form-task .modal-body .input-group[class^="col-"], #cividocuments form.form-task .modal-body .input-group[class^="col-"], #civitasks form.form-document .modal-body .input-group[class^="col-"], #cividocuments form.form-document .modal-body .input-group[class^="col-"] {

--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -2952,7 +2952,6 @@
   text-decoration: none;
 }
 #civitasks a:focus, #cividocuments a:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -4507,7 +4506,6 @@
 #cividocuments input[type="radio"]:focus,
 #civitasks input[type="checkbox"]:focus,
 #cividocuments input[type="checkbox"]:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -5194,7 +5192,6 @@ fieldset[disabled]
   user-select: none;
 }
 #civitasks .btn:focus, #cividocuments .btn:focus, #civitasks .btn.focus, #cividocuments .btn.focus, #civitasks .btn:active:focus, #cividocuments .btn:active:focus, #civitasks .btn:active.focus, #cividocuments .btn:active.focus, #civitasks .btn.active:focus, #cividocuments .btn.active:focus, #civitasks .btn.active.focus, #cividocuments .btn.active.focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -11359,7 +11356,7 @@ fieldset[disabled]
   /* using this override until we have a separate directive for that */
 }
 #civitasks form.form-task .modal-header .close, #cividocuments form.form-task .modal-header .close, #civitasks form.form-document .modal-header .close, #cividocuments form.form-document .modal-header .close {
-  margin-top: 7px;
+  margin-top: 5px;
   margin-left: -3px;
 }
 #civitasks form.form-task .modal-header > *[class^='col-'], #cividocuments form.form-task .modal-header > *[class^='col-'], #civitasks form.form-document .modal-header > *[class^='col-'], #cividocuments form.form-document .modal-header > *[class^='col-'] {
@@ -11495,6 +11492,12 @@ fieldset[disabled]
 }
 #civitasks form.form-assignment .separately, #cividocuments form.form-assignment .separately {
   margin-bottom: 20px;
+}
+#civitasks form.form-assignment .separately label, #cividocuments form.form-assignment .separately label, #civitasks form.form-assignment .separately .checkbox-label, #cividocuments form.form-assignment .separately .checkbox-label,
+#civitasks form.form-assignment .separately .radio-label,
+#cividocuments form.form-assignment .separately .radio-label {
+  margin-top: 3px;
+  margin-bottom: 12px;
 }
 #civitasks form.form-task-migrate label, #cividocuments form.form-task-migrate label, #civitasks form.form-task-migrate .checkbox-label, #cividocuments form.form-task-migrate .checkbox-label,
 #civitasks form.form-task-migrate .radio-label,

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/partials/_forms.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/partials/_forms.scss
@@ -171,7 +171,7 @@ select[required] + .crm_custom-select__arrow::after {
 }
 
 .ui-select-match-text {
-  color: $input-color;
+  color: $input-color !important;
 }
 
 .ui-select-toggle[disabled] {

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_forms.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_forms.scss
@@ -120,7 +120,7 @@ form {
 
           .ui-select-placeholder,
           .ui-select-match-text {
-            color: #41afcb !important;
+            color: $input-color !important;
             font-size: 20px !important;
           }
         }

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_forms.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_forms.scss
@@ -278,6 +278,11 @@ form {
 
     .separately {
       margin-bottom: 20px;
+
+      label {
+        margin-top: 3px;
+        margin-bottom: 12px;
+      }
     }
   }
 

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
@@ -11,8 +11,7 @@
     <section class="container">
       <div class="col-xs-12">
         <div class="row separately">
-          <h2 class="col-xs-12 col-sm-3 control-label required-field-indicator">Contact:</h2>
-
+          <label class="col-xs-12 col-sm-3 control-label required-field-indicator">Target Contact:</label>
           <div ng-if="showCId" class="col-xs-12 col-sm-5">
             <ui-select allow-clear name="contact" theme="civihr-ui-select" ng-model="assignment.contact_id" ng-change="assignment.client_id=assignment.contact_id" on-select="cacheContact($item)" ng-required="true">
               <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">


### PR DESCRIPTION
### Issue:
The input placeholder's and ui-select-placeholder's color needed to be changed to `#999999`.

### Solution
1. Add new color as scss variable  and override ui-select-placeholder existing color.
2. Maintain the color of the selected and chosen values as previously available.

### Screenshot:
1. Before 
<img width="508" alt="screen shot 2017-03-10 at 9 09 30 pm" src="https://cloud.githubusercontent.com/assets/6307362/23800898/346fd94a-05d6-11e7-8aae-126f90335289.png">

2. After
<img width="510" alt="screen shot 2017-03-10 at 9 11 09 pm" src="https://cloud.githubusercontent.com/assets/6307362/23800884/277ef6d0-05d6-11e7-9393-15a5867d21f5.png">
