### PR TITLE
PCHR-1910: Make subject field in New Task modal to full-width

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
@@ -66,7 +66,7 @@
             </a>
           </span>
         </div>
-        <div class="col-xs-12 col-sm-6" ng-show="task.subject || showFieldSubject">
+        <div class="col-xs-12 col-sm-12" ng-show="task.subject || showFieldSubject">
           <input id="{{prefix}}task-subject" class="form-control" name="taskSubject" ng-model="task.subject" placeholder="Subject" maxlength="255" />
         </div>
       </div>


### PR DESCRIPTION
### Issue:
Currently `col-sm-6` is used which only takes  six columns  resulting to display the subject field as half-width.

### Solution:
Add `col-sm-12` instead of `col-sm-6` for subject field container.

### Screenshots:
#### Before:
<img width="510" alt="screen shot 2017-03-14 at 1 44 44 pm" src="https://cloud.githubusercontent.com/assets/6307362/23891116/d77289d8-08bc-11e7-91f6-8406f4ffc133.png">

#### After:
<img width="508" alt="screen shot 2017-03-14 at 1 43 42 pm" src="https://cloud.githubusercontent.com/assets/6307362/23891126/e8c3e830-08bc-11e7-9e93-f650becc2a98.png">
