### PR TITLE
PCHR-1921-1926: Fix padding in document and assignment modal

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -2952,7 +2952,6 @@
   text-decoration: none;
 }
 #civitasks a:focus, #cividocuments a:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -4507,7 +4506,6 @@
 #cividocuments input[type="radio"]:focus,
 #civitasks input[type="checkbox"]:focus,
 #cividocuments input[type="checkbox"]:focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -5194,7 +5192,6 @@ fieldset[disabled]
   user-select: none;
 }
 #civitasks .btn:focus, #cividocuments .btn:focus, #civitasks .btn.focus, #cividocuments .btn.focus, #civitasks .btn:active:focus, #cividocuments .btn:active:focus, #civitasks .btn:active.focus, #cividocuments .btn:active.focus, #civitasks .btn.active:focus, #cividocuments .btn.active:focus, #civitasks .btn.active.focus, #cividocuments .btn.active.focus {
-  outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }
@@ -11359,7 +11356,7 @@ fieldset[disabled]
   /* using this override until we have a separate directive for that */
 }
 #civitasks form.form-task .modal-header .close, #cividocuments form.form-task .modal-header .close, #civitasks form.form-document .modal-header .close, #cividocuments form.form-document .modal-header .close {
-  margin-top: 7px;
+  margin-top: 5px;
   margin-left: -3px;
 }
 #civitasks form.form-task .modal-header > *[class^='col-'], #cividocuments form.form-task .modal-header > *[class^='col-'], #civitasks form.form-document .modal-header > *[class^='col-'], #cividocuments form.form-document .modal-header > *[class^='col-'] {

--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -11331,10 +11331,9 @@ fieldset[disabled]
   background: none;
 }
 #civitasks form.form-horizontal .input-group.date-input-group, #cividocuments form.form-horizontal .input-group.date-input-group {
+  margin-left: 0;
+  margin-right: 0;
   text-align: right;
-}
-#civitasks form.form-horizontal .input-group.date-input-group input, #cividocuments form.form-horizontal .input-group.date-input-group input {
-  width: 105px;
 }
 #civitasks form.form-task .form-control-static a:link, #cividocuments form.form-task .form-control-static a:link, #civitasks form.form-document .form-control-static a:link, #cividocuments form.form-document .form-control-static a:link {
   font-size: 12px;
@@ -11440,6 +11439,9 @@ fieldset[disabled]
 }
 #civitasks form.form-task .modal-body .container, #cividocuments form.form-task .modal-body .container, #civitasks form.form-document .modal-body .container, #cividocuments form.form-document .modal-body .container {
   padding: 0 15px;
+}
+#civitasks form.form-task .modal-body .container .show-more, #cividocuments form.form-task .modal-body .container .show-more, #civitasks form.form-document .modal-body .container .show-more, #cividocuments form.form-document .modal-body .container .show-more {
+  padding-top: 10px;
 }
 #civitasks form.form-task h3, #cividocuments form.form-task h3, #civitasks form.form-document h3, #cividocuments form.form-document h3 {
   margin-top: 0;

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/_bootstrap-variables.sass
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civihr/_bootstrap-variables.sass
@@ -100,7 +100,7 @@ $headings-color:          $gray-darker
 //$padding-base-vertical:     6px
 // $padding-base-horizontal:   12px
 
-// $padding-large-vertical:    10px
+$padding-large-vertical:    10px
 // $padding-large-horizontal:  16px
 
 // $padding-small-vertical:    5px

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_forms.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_forms.scss
@@ -40,11 +40,9 @@ form {
   &.form-horizontal {
 
     .input-group.date-input-group {
+      margin-left: 0;
+      margin-right: 0;
       text-align: right;
-
-      input{
-        width: 105px;
-      }
     }
   }
 
@@ -185,6 +183,10 @@ form {
 
       .container {
         padding: 0 15px;
+
+        .show-more {
+          padding-top: $padding-large-vertical;
+        }
       }
     }
 

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
@@ -13,7 +13,7 @@
         <div class="row separately">
           <h2 class="col-xs-12 col-sm-3 control-label required-field-indicator">Contact:</h2>
 
-          <div ng-if="showCId" class="col-xs-12 col-sm-5">
+          <div ng-if="showCId" class="col-xs-12 col-sm-4">
             <ui-select allow-clear name="contact" theme="civihr-ui-select" ng-model="assignment.contact_id" ng-change="assignment.client_id=assignment.contact_id" on-select="cacheContact($item)" ng-required="true">
               <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">
                 {{$select.selected.label}}
@@ -24,13 +24,13 @@
               </ui-select-choices>
             </ui-select>
           </div>
-          <div ng-if="!showCId" class="col-xs-12 col-sm-5 display-only header">
+          <div ng-if="!showCId" class="col-xs-12 col-sm- display-only header">
             <span ng-bind="cache.contact.obj[assignment.contact_id].sort_name || 'No target contact'"></span>
           </div>
         </div>
         <div class="row required">
           <label class="col-xs-12 col-sm-3 control-label required-field-indicator">Assignment Type:</label>
-          <div class="col-xs-12 col-sm-5">
+          <div class="col-xs-12 col-sm-4">
             <div class="crm_custom-select crm_custom-select--full">
               <select name="assignment" ng-class="{'has-error': assignmentForm.assignment.$invalid}" ng-required="true" class="form-control" ng-change="setData()" ng-model="assignment.case_type_id" ng-options="value.id as value.title for value in cache.assignmentType.arr">
                 <option value="">- select -</option>
@@ -41,7 +41,7 @@
           <label class="col-xs-12 col-sm-2 control-label no-wrap required-field-indicator" for="{{prefix}}assignment-due">
             Key Date:
           </label>
-          <div class="col-xs-12 col-sm-2">
+          <div class="col-xs-12 col-sm-3">
             <div class="input-group input-group-unstyled date-input-group form-group" ng-class="{'has-error': assignmentForm.dueDate.$invalid}">
               <input type="text" id="{{prefix}}assignment-due" ng-model="assignment.dueDate" name="dueDate" class="form-control" placeholder="{{ format }}" name="assignmentDue" ng-required="true" uib-datepicker-popup ng-model="assignment.dueDate" is-open="dpOpened.assignmentDue"
                   ng-click="dpOpen($event, 'assignmentDue');">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
@@ -24,7 +24,7 @@
               </ui-select-choices>
             </ui-select>
           </div>
-          <div ng-if="!showCId" class="col-xs-12 col-sm- display-only header">
+          <div ng-if="!showCId" class="col-xs-12 col-sm-5 display-only header">
             <span ng-bind="cache.contact.obj[assignment.contact_id].sort_name || 'No target contact'"></span>
           </div>
         </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -150,7 +150,7 @@
       </div>
       <!-- Show More -->
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-xs-12 show-more">
           <span ng-click="expanded = !expanded;"><i class="fa" ng-class="{'fa-chevron-down': expanded, 'fa-chevron-right': !expanded}"></i> Show more</span>
         </div>
       </div>


### PR DESCRIPTION
### Note: This PR include the Fix for two tickets PCHR-1921 and PCHR-1926 + Small fix for PCHR-1909

### Issue:
1. Need more top padding for show more label in New Document Modal T&A 
2. Need more right padding for key date field in New Assignment Modal in T&A

### Solution:
1. Add a class 'show-more` with top padding as 10px in New Document Modal. 
2. Remove explicit width defined for key-date field 
by modifying the following file `uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/partials/_forms.scss`.

### Note: 
Added a fix `margin-top: 5px` for close button in modals in T&A" in commit 
`PCHR-1909: Fix style margin-top for close icon` which was missing in https://github.com/compucorp/civihr-tasks-assignments/commit/581bb9ee11b124bb032eb1baa06d2025a81f526a . 

### Issue with adding `outline: thin dotted`
The style `outline: thin dotted` is added automatically while compiling sass by gulp using  ruby gem bootstrap-sass prior to v3.3.7. As we won't need it,  it is necessary to use  latest version of bootstrap-sass or greater than v3.3.7 which will remove/won't add `outline: thin dotted`.

### Screenshots:
#### 1. Before:
##### New Document Modal
<img width="514" alt="screen shot 2017-03-15 at 7 03 13 pm" src="https://cloud.githubusercontent.com/assets/6307362/23984435/ae65fb5c-0a41-11e7-94b4-e172696d726f.png">

##### New Assignment Modal
<img width="813" alt="screen shot 2017-03-16 at 12 13 14 pm" src="https://cloud.githubusercontent.com/assets/6307362/23984530/08c1013c-0a42-11e7-98a6-78f79dd0bcfa.png">

#### 2. After:
##### New Document Modal
<img width="460" alt="screen shot 2017-03-15 at 9 22 57 pm" src="https://cloud.githubusercontent.com/assets/6307362/23984452/c39ad42a-0a41-11e7-8b61-a8f28f4471c5.png">

##### New Assignment Modal
<img width="813" alt="screen shot 2017-03-15 at 9 22 16 pm" src="https://cloud.githubusercontent.com/assets/6307362/23984447/bc28e2a4-0a41-11e7-8be9-87c27f914fbf.png">
