### PR TITLE
PCHR-2088: Increased Date fields width in T&A dashboard

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/key-dates.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/key-dates.html
@@ -22,7 +22,7 @@
                     <div class="form-horizontal" uib-collapse="isCollapsed.filterDates">
                         <div class="form-group">
                             <label for="{{prefix}}filter-date-from" class="col-xs-12 col-sm-3 control-label">From</label>
-                            <div class="input-group col-xs-12 col-sm-9 col-lg-7">
+                            <div class="input-group col-xs-12 col-sm-9 col-lg-8">
                                 <input
                                         is-open="dpOpened.filterDates.from"
                                         uib-datepicker-popup="dd/MM/yyyy"
@@ -35,7 +35,7 @@
                         </div>
                         <div class="form-group">
                             <label for="{{prefix}}filter-date-until" class="col-xs-12 col-sm-3 control-label">Until</label>
-                            <div class="input-group col-xs-12 col-sm-9  col-lg-7">
+                            <div class="input-group col-xs-12 col-sm-9  col-lg-8">
                                 <input
                                         is-open="dpOpened.filterDates.until"
                                         uib-datepicker-popup="dd/MM/yyyy"

--- a/uk.co.compucorp.civicrm.tasksassignments/views/directives/sidebar-filters.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/directives/sidebar-filters.html
@@ -20,7 +20,7 @@
       <label for="{{prefix}}filter-date-from" class="col-xs-12 col-sm-3 control-label">
         From
       </label>
-      <div class="input-group col-xs-12 col-sm-9 col-lg-7">
+      <div class="input-group col-xs-12 col-sm-9 col-lg-8">
         <input
           is-open="dpOpened.filterDates.from"
           uib-datepicker-popup="dd/MM/yyyy"
@@ -35,7 +35,7 @@
       <label for="{{prefix}}filter-date-until" class="col-xs-12 col-sm-3 control-label">
         Until
       </label>
-      <div class="input-group col-xs-12 col-sm-9  col-lg-7">
+      <div class="input-group col-xs-12 col-sm-9  col-lg-8">
         <input
           is-open="dpOpened.filterDates.until"
           uib-datepicker-popup="dd/MM/yyyy"


### PR DESCRIPTION
### Issue:
The date fields in filters in T&A dashboard currently are small and needs to increase their width little longer to display full date.

### Solution:
Add replace `col-lg-7` by `col-lg-8`  in each date field's container in  following files:
1. `uk.co.compucorp.civicrm.tasksassignments/views/directives/sidebar-filters.html`
2. `uk.co.compucorp.civicrm.tasksassignments/views/dashboard/key-dates.html`

### Screenshot:
1. In Tasks:
![screen shot 2017-03-20 at 5 23 02 pm](https://cloud.githubusercontent.com/assets/6307362/24098573/49916a18-0d93-11e7-990f-4ddb47028b15.png)

2. Key Dates:
![screen shot 2017-03-20 at 5 23 16 pm](https://cloud.githubusercontent.com/assets/6307362/24098576/4c2a954c-0d93-11e7-88ef-deda0b6fea61.png)

