### PR TITLE
PCHR-2064: Changes for adopting shoreditch theme

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -34,7 +34,7 @@
   Author : Austin Anderson
   License : 2013 MIT
   Version 1.3.7
-  
+
   See README.md or https://github.com/fraywing/textAngular/wiki for requirements and use.
   */
   /* add generic styling for the editor */
@@ -12413,7 +12413,7 @@ fieldset[disabled]
   content: '\f0d8';
 }
 #civitasks .civihr-ui-select .select2-chosen, #cividocuments .civihr-ui-select .select2-chosen {
-  color: #5b656e !important;
+  color: #727E8A !important;
   padding-left: 5px !important;
 }
 #civitasks .civihr-ui-select .select2-drop-active, #cividocuments .civihr-ui-select .select2-drop-active {

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
@@ -9,8 +9,8 @@ $gray-lighter:           #F3F6F7;
 $input-border-radius:    0;
 
 // Include the original ui-select css + the civihr-ui-select dropdown theme
-@import "../../../../../civihr/org.civicrm.bootstrapcivicrm/scss/bootstrap/vendor/ui-select/ui-select";
-@import "../../../../../civihr/org.civicrm.bootstrapcivicrm/scss/bootstrap/components/civihr-ui-select/civihr-ui-select";
+@import "../../../../../civihr/org.civicrm.shoreditch/scss/bootstrap/vendor/ui-select/ui-select";
+@import "../../../../../civihr/org.civicrm.shoreditch/scss/bootstrap/components/civihr-ui-select/civihr-ui-select";
 
 // Customizations specific for T&A
 .civihr-ui-select {

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
@@ -1,6 +1,6 @@
 // This is all temporary until the Bootstrap consolidation happens!
 
-// Override variables so they match the values in the shoreditch theme
+// Override variables so they match the values of the old theme
 $brand-danger:           #E6807F;
 $brand-primary:          #42AFCB;
 $dropdown-border:        #727E8A;

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
@@ -95,7 +95,7 @@
                 </tr>
               </thead>
               <tbody>
-                <tr ng-repeat="activity in taskList" ng-controller="ModalAssignmentActivityCtrl" ng-class="{required: !isDisabled && activity.create}">
+                <tr ng-repeat="activity in taskList" ng-controller="ModalAssignmentActivityCtrl">
                   <td ng-if="!activity.isAdded">
                     <input type="checkbox" ng-model="activity.create" ng-change="!activity.create && (activity.assignee_contact_id = undefined) || (activity.activity_date_time = undefined);" ng-disabled="isDisabled">
                   </td>
@@ -176,7 +176,7 @@
                 </tr>
               </thead>
               <tbody>
-                <tr ng-repeat="activity in documentList" ng-controller="ModalAssignmentActivityCtrl" ng-class="{required: !isDisabled && activity.create}">
+                <tr ng-repeat="activity in documentList" ng-controller="ModalAssignmentActivityCtrl">
                   <td ng-if="!activity.isAdded">
                     <input type="checkbox" ng-model="activity.create" ng-change="!activity.create && (activity.assignee_contact_id = undefined) || (activity.activity_date_time = undefined);" ng-disabled="isDisabled">
                   </td>


### PR DESCRIPTION
# Problem
Using the [org.civicrm.shoreditch](https://github.com/civicrm/org.civicrm.shoreditch) theme would cause a misalignment in the tasks list in the assignments modal

<img width="400" alt="task-list-before" src="https://cloud.githubusercontent.com/assets/6400898/24363834/464ca600-1311-11e7-92d9-049a63a9f6d8.png">

This was caused by the entire rows to have the `.required` class, that would match the `.crm-container .required` selector in the new theme, which finally would add the red * that would misalign the table

# Solution
The `required` class wasn't required anyway on the rows, so it has been removed thus fixing the problem

<img width="400" alt="task-list-after" src="https://cloud.githubusercontent.com/assets/6400898/24363897/77110baa-1311-11e7-8eaa-3da44f18dcfd.png">

## Additional fix
The temporary partial for the ui-select dropdown (see #172 ) contained a reference to the shoreditch theme, which was incorrect, as by using the values contained in the shoreditch theme would change the colors of the dropdown. The right reference is to the old theme instead (`org.civicrm.bootstrapcivicrm`)