### PR TITLE
PCHR-2103: Make task list consistent in contact calendar tasks and in dashboard

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -104,8 +104,17 @@
             <div editable-ta="task.details" onbeforesave="updateTask(task, { details: ta.$data });">
               <div ta-bind ng-model="task.details"></div>
             </div>
-            <p class="{{prefix}}task-contact-source">Created by:&nbsp; <a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.source_contact_id].id}}"><span ng-bind="cache.contact.obj[task.source_contact_id].sort_name"></span></a></p>
           </div>
+        </div>
+        <div class="col-xs-8">
+          <p class="{{prefix}}task-contact-source">
+            Created by:&nbsp;
+            <a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.source_contact_id].id}}">
+              <span ng-bind="cache.contact.obj[task.source_contact_id].sort_name"></span>
+            </a>
+            &nbsp;-&nbsp;
+            <span class="{{prefix}}task-status" ng-bind="cache.taskStatus.obj[task.status_id]"></span>
+          </p>
         </div>
       </article>
     </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -71,6 +71,7 @@
           <div ng-bind="contact.label"></div>
           <small ng-bind="contact.description[0]"></small>
         </editable-ui-select-choices>
+        <i class="fa fa-pencil"></i>
         {{cache.contact.obj[task.assignee_contact_id[0]].sort_name}}
         </span>
     </div>
@@ -80,10 +81,12 @@
       <p class="{{prefix}}task-subject">
         Due:
         <time editable-bsdate="task.activity_date_time" onbeforesave="updateTask(task, { activity_date_time: $data });" onshow="dpOpen()" class="editable-small" e-ng-click="dpOpen()" e-is-open="picker.opened" e-show-calendar-button="false" e-datepicker-popup>
+          <i class="fa fa-pencil"></i>
           {{task.activity_date_time | date: 'MMM d'}}
         </time>
         <span ng-if="!!task.subject">Subject: </span>
         <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
+          <i class="fa fa-pencil"></i>
           {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
         </span>
       </p>
@@ -103,6 +106,7 @@
           <div class="{{prefix}}task-more">
             <div editable-ta="task.details" onbeforesave="updateTask(task, { details: ta.$data });">
               <div ta-bind ng-model="task.details"></div>
+              <i class="fa fa-pencil"></i>
             </div>
           </div>
         </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -85,7 +85,7 @@
           {{task.activity_date_time | date: 'MMM d'}}
         </time>
         <span>Subject:</span>
-        <span ng-if="!!task.subject" editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
+        <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
           <i class="fa fa-pencil"></i>
           {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
         </span>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -1,145 +1,113 @@
 <div class="{{prefix}}page-contact" ct-civi-events>
-    <div class="panel panel-default">
-        <div class="panel-body">
-            <div class="row">
-                <div class="col-xs-12 col-sm-6 col-lg-8">
-                    <button class="btn btn-default btn-primary" ng-click="modalTask()">
-                        <span class="fa fa-plus-circle" aria-hidden="true"></span> &nbsp;Add Task
-                    </button>
-                    &nbsp;
-                    <button class="btn btn-default btn-primary"
-                            ng-click="modalAssignment()"
-                            ng-if="settings.extEnabled.assignments">
-                        <span class="fa fa-plus-circle" aria-hidden="true"></span> &nbsp;
-                        {{settings.copy.button.assignmentAdd || 'Add Assignment'}}
-                    </button>
-                </div>
-                <div class="col-xs-12 col-sm-6 col-lg-4" ng-if="settings.extEnabled.assignments">
-                    <ui-select
-                            multiple
-                            ng-model="filterParams.assignmentType">
-                        <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
-                        <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
-                            <div ng-bind-html="type.title | highlight: $select.search"></div>
-                        </ui-select-choices>
-                    </ui-select>
-                </div>
-            </div>
+  <div class="panel panel-default">
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-xs-12 col-sm-6 col-lg-8">
+          <button class="btn btn-default btn-primary" ng-click="modalTask()">
+            <span class="fa fa-plus-circle" aria-hidden="true"></span> &nbsp;Add Task
+          </button> &nbsp;
+          <button class="btn btn-default btn-primary" ng-click="modalAssignment()" ng-if="settings.extEnabled.assignments">
+            <span class="fa fa-plus-circle" aria-hidden="true"></span> &nbsp;
+            {{settings.copy.button.assignmentAdd || 'Add Assignment'}}
+          </button>
         </div>
+        <div class="col-xs-12 col-sm-6 col-lg-4" ng-if="settings.extEnabled.assignments">
+          <ui-select multiple ng-model="filterParams.assignmentType">
+            <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
+            <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
+              <div ng-bind-html="type.title | highlight: $select.search"></div>
+            </ui-select-choices>
+          </ui-select>
+        </div>
+      </div>
     </div>
-    <h4 class="header-bar header-bar-primary" ng-show="listOngoing.length">Ongoing:</h4>
+  </div>
+  <h4 class="header-bar header-bar-primary" ng-show="listOngoing.length">Ongoing:</h4>
+  <ul class="{{prefix}}list-task">
+    <li ng-repeat="task in listOngoing = (listFiltered = (list | filterByAssignmentType:filterParams.assignmentType | orderBy: 'activity_date_time') | filterByStatus:cache.taskStatusResolve:false)" ng-controller="TaskCtrl" ng-class="{
+      '{{prefix}}task-completed': task.completed,
+      '{{prefix}}task-due': task.due
+      }" ng-include src="'task.html'" ct-spinner ct-spinner-id="task{{task.id}}">
+    </li>
+  </ul>
+  <h4 class="header-bar header-bar-danger">Resolved:
+    <a href class="pull-right" ng-click="loadTasksResolved(); isCollapsed.taskListResolved = !isCollapsed.taskListResolved">
+      <i ng-class="{fa: true, 'fa-chevron-down': !isCollapsed.taskListResolved, 'fa-chevron-up': isCollapsed.taskListResolved }"></i>
+    </a>
+  </h4>
+  <div uib-collapse="isCollapsed.taskListResolved">
+    <div class="well {{prefix}}spinner-container" ng-show="!listResolvedLoaded">
+      Loading resolved tasks...
+      <div class="{{prefix}}spinner-cover {{prefix}}spinner-img"></div>
+    </div>
+    <div class="alert alert-danger" ng-show="listResolvedLoaded && !listResolved.length">No results found.</div>
     <ul class="{{prefix}}list-task">
-        <li ng-repeat="task in listOngoing = (listFiltered = (list | filterByAssignmentType:filterParams.assignmentType | orderBy: 'activity_date_time') | filterByStatus:cache.taskStatusResolve:false)"
-            ng-controller="TaskCtrl"
-            ng-class="{
-                '{{prefix}}task-completed': task.completed,
-                '{{prefix}}task-due': task.due
-            }"
-            ng-include
-            src="'task.html'"
-            ct-spinner
-            ct-spinner-id="task{{task.id}}">
-        </li>
+      <li ng-repeat="task in listResolved = (listFiltered | filterByStatus:cache.taskStatusResolve:true)" ng-controller="TaskCtrl" ng-class="'{{prefix}}task-resolved'" ng-include src="'task.html'" ct-spinner>
+      </li>
     </ul>
-    <h4 class="header-bar header-bar-danger">Resolved:
-        <a href class="pull-right" ng-click="loadTasksResolved(); isCollapsed.taskListResolved = !isCollapsed.taskListResolved">
-            <i ng-class="{fa: true, 'fa-chevron-down': !isCollapsed.taskListResolved, 'fa-chevron-up': isCollapsed.taskListResolved }"></i>
-        </a>
-    </h4>
-    <div uib-collapse="isCollapsed.taskListResolved">
-        <div class="well {{prefix}}spinner-container" ng-show="!listResolvedLoaded">
-            Loading resolved tasks...
-            <div class="{{prefix}}spinner-cover {{prefix}}spinner-img"></div>
-        </div>
-        <div class="alert alert-danger" ng-show="listResolvedLoaded && !listResolved.length">No results found.</div>
-        <ul class="{{prefix}}list-task">
-            <li ng-repeat="task in listResolved = (listFiltered | filterByStatus:cache.taskStatusResolve:true)"
-                ng-controller="TaskCtrl"
-                ng-class="'{{prefix}}task-resolved'"
-                ng-include
-                src="'task.html'"
-                ct-spinner>
-            </li>
-        </ul>
-    </div>
+  </div>
 </div>
 
 <script type="text/ng-template" id="task.html">
-    <header class="row">
-        <div class="col-xs-6">
-            <input type="checkbox"
-                   ng-change="changeStatus(task, 2)"
-                   ng-disabled="task.completed"
-                   ng-model="task.completed"
-                   class="{{prefix}}task-checkbox"
-                   name="task">
-            <a href class="{{prefix}}task-title"  ng-click="modalTask(task);" ng-bind="cache.taskType.obj[task.activity_type_id]"></a>
-        </div>
-        <div class="col-xs-6">
-            <div class="dropdown" uib-dropdown>
-                <a href class="dropdown-toggle {{prefix}}context-menu-toggle pull-right" uib-dropdown-toggle><i class="fa fa-ellipsis-v"></i></a>
-                <ul class="dropdown-menu pull-right" uib-dropdown-menu>
-                    <li><a href ng-click="modalTask(task);"><i class="fa fa-pencil"></i> Edit</a></li>
-                    <li><a href ng-click="modalReminder(task, 'task');"><i class="fa fa-envelope-o"></i> Send reminder</a></li>
-                    <li ng-if="permissions.allowDelete"><a href ng-click="deleteTask(task);"><i class="fa fa-trash-o"></i> Delete</a></li>
-                </ul>
-            </div>
-            Assigned to: <span
-                editable-ui-select="task.assignee_contact_id[0]"
-                theme="civihr-ui-select"
-                e-required="true"
-                ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.assignee_contact_id[0]].id}}"
-                onshow="updateContacts(cache.contact.arrSearch);"
-                onbeforesave="updateTask(task, { assignee_contact_id: [$data] });"
-                on-select="cacheContact($item);">
-                <editable-ui-select-match
-                        placeholder="Start typing a name or email...">{{$select.selected.label}}</editable-ui-select-match>
-                <editable-ui-select-choices  repeat="contact.id as contact in contacts | filter: $select.search"
-                                             refresh="refreshContacts($select.search)"
-                                             refresh-delay="0">
-                    <div ng-bind="contact.label"></div>
-                    <small ng-bind="contact.description[0]"></small>
-                </editable-ui-select-choices>
-                {{cache.contact.obj[task.assignee_contact_id[0]].sort_name}}
-            </span>
-        </div>
-    </header>
-    <div class="row">
-        <div class="col-xs-6">
-            <p class="{{prefix}}task-subject">
-              Due:
-              <time editable-bsdate="task.activity_date_time"
-                onbeforesave="updateTask(task, { activity_date_time: $data });"
-                onshow="dpOpen()"
-                class="editable-small"
-                e-ng-click="dpOpen()"
-                e-is-open="picker.opened"
-                e-show-calendar-button="false"
-                e-datepicker-popup>
-                {{task.activity_date_time | date: 'MMM d'}}
-              </time>
-              <span ng-if="!!task.subject">Subject: </span>
-              <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
-                {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
-              </span>
-            </p>
-        </div>
+  <header class="row">
+    <div class="col-xs-6">
+      <input type="checkbox" ng-change="changeStatus(task, 2)" ng-disabled="task.completed" ng-model="task.completed" class="{{prefix}}task-checkbox" name="task">
+      <a href class="{{prefix}}task-title" ng-click="modalTask(task);" ng-bind="cache.taskType.obj[task.activity_type_id]"></a>
     </div>
-    <div class="row">
+    <div class="col-xs-6">
+      <div class="dropdown" uib-dropdown>
+        <a href class="dropdown-toggle {{prefix}}context-menu-toggle pull-right" uib-dropdown-toggle><i class="fa fa-ellipsis-v"></i></a>
+        <ul class="dropdown-menu pull-right" uib-dropdown-menu>
+          <li><a href ng-click="modalTask(task);"><i class="fa fa-pencil"></i> Edit</a></li>
+          <li><a href ng-click="modalReminder(task, 'task');"><i class="fa fa-envelope-o"></i> Send reminder</a></li>
+          <li ng-if="permissions.allowDelete"><a href ng-click="deleteTask(task);"><i class="fa fa-trash-o"></i> Delete</a></li>
+        </ul>
+      </div>
+      Assigned to:
+      <span editable-ui-select="task.assignee_contact_id[0]" theme="civihr-ui-select" e-required="true" ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.assignee_contact_id[0]].id}}" onshow="updateContacts(cache.contact.arrSearch);"
+          onbeforesave="updateTask(task, { assignee_contact_id: [$data] });" on-select="cacheContact($item);">
+        <editable-ui-select-match placeholder="Start typing a name or email...">{{$select.selected.label}}</editable-ui-select-match>
+        <editable-ui-select-choices repeat="contact.id as contact in contacts | filter: $select.search" refresh="refreshContacts($select.search)" refresh-delay="0">
+          <div ng-bind="contact.label"></div>
+          <small ng-bind="contact.description[0]"></small>
+        </editable-ui-select-choices>
+        {{cache.contact.obj[task.assignee_contact_id[0]].sort_name}}
+        </span>
+    </div>
+  </header>
+  <div class="row">
+    <div class="col-xs-6">
+      <p class="{{prefix}}task-subject">
+        Due:
+        <time editable-bsdate="task.activity_date_time" onbeforesave="updateTask(task, { activity_date_time: $data });" onshow="dpOpen()" class="editable-small" e-ng-click="dpOpen()" e-is-open="picker.opened" e-show-calendar-button="false" e-datepicker-popup>
+          {{task.activity_date_time | date: 'MMM d'}}
+        </time>
+        <span ng-if="!!task.subject">Subject: </span>
+        <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
+          {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
+        </span>
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <a href ng-click="isCollapsed = !isCollapsed" class="btn btn-collapse">
+        <span class="fa"
+          ng-class="{fa: true, 'fa-chevron-down': !isCollapsed, 'fa-chevron-right': isCollapsed }"
+          aria-hidden="true">
+        </span>
+        Show More
+      </a>
+      <article class="row" uib-collapse="isCollapsed">
         <div class="col-xs-12">
-            <a href ng-click="isCollapsed = !isCollapsed" class="btn btn-collapse"><span
-                    class="fa"
-                    ng-class="{fa: true, 'fa-chevron-down': !isCollapsed, 'fa-chevron-right': isCollapsed }"
-                    aria-hidden="true"></span> Show More</a>
-            <article class="row" uib-collapse="isCollapsed">
-                <div class="col-xs-12">
-                    <div class="{{prefix}}task-more">
-                        <div editable-ta="task.details"
-                             onbeforesave="updateTask(task, { details: ta.$data });"><div ta-bind ng-model="task.details"></div></div>
-                        <p class="{{prefix}}task-contact-source">Created by:&nbsp; <a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.source_contact_id].id}}"><span ng-bind="cache.contact.obj[task.source_contact_id].sort_name"></span></a></p>
-                    </div>
-                </div>
-            </article>
+          <div class="{{prefix}}task-more">
+            <div editable-ta="task.details" onbeforesave="updateTask(task, { details: ta.$data });">
+              <div ta-bind ng-model="task.details"></div>
+            </div>
+            <p class="{{prefix}}task-contact-source">Created by:&nbsp; <a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.source_contact_id].id}}"><span ng-bind="cache.contact.obj[task.source_contact_id].sort_name"></span></a></p>
+          </div>
         </div>
+      </article>
     </div>
+  </div>
 </script>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -84,8 +84,8 @@
           <i class="fa fa-pencil"></i>
           {{task.activity_date_time | date: 'MMM d'}}
         </time>
-        <span ng-if="!!task.subject">Subject: </span>
-        <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
+        <span>Subject:</span>
+        <span ng-if="!!task.subject" editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
           <i class="fa fa-pencil"></i>
           {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
         </span>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
@@ -60,8 +60,8 @@
           <i class="fa fa-pencil"></i>
           {{task.activity_date_time | date: 'MMM d'}}
         </time>
-        <span ng-if="!!task.subject">Subject: </span>
-        <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
+        <span>Subject:</span>
+        <span ng-if="!!task.subject" editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
           <i class="fa fa-pencil"></i>
           {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
         </span>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
@@ -1,132 +1,108 @@
 <h4 class="header-bar header-bar-dark">Tasks:</h4>
 <ul class="{{prefix}}list-task {{prefix}}list-task-small">
-  <li
-    ng-repeat="task in listOngoing = (list
-      | filterByStatus:cache.taskStatusResolve:false
-      | filterByDue:'dateRange':{ from: calendarDay, until: calendarDay }
-      | orderBy: 'activity_date_time')"
+  <li ng-repeat="task in listOngoing = (list
+    | filterByStatus:cache.taskStatusResolve:false
+    | filterByDue:'dateRange':{ from: calendarDay, until: calendarDay }
+    | orderBy: 'activity_date_time')"
     ng-controller="TaskCtrl"
     ng-class="{
       '{{prefix}}task-completed': task.completed,
       '{{prefix}}task-due': task.due
     }"
-    ng-include
-    src="'task.html'"
-    ct-spinner
-    ct-spinner-id="task{{task.id}}">
+    ng-include src="'task.html'"
+    ct-spinner ct-spinner-id="task{{task.id}}">
   </li>
 </ul>
 
 <script type="text/ng-template" id="task.html">
-    <header class="row">
-        <div class="col-xs-6">
-            <input type="checkbox"
-                   ng-change="changeStatus(task, 2)"
-                   ng-disabled="task.completed"
-                   ng-model="task.completed"
-                   class="{{prefix}}task-checkbox"
-                   name="task">
-            <a href class="{{prefix}}task-title"  ng-click="modalTask(task);" ng-bind="cache.taskType.obj[task.activity_type_id]"></a>:
-            <span
-                    editable-ui-select="task.target_contact_id[0]"
-                    e-required="true"
-                    ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.target_contact_id[0]].id}}"
-                    onbeforesave="updateTask(task, { target_contact_id: [$data] });"
-                    onshow="updateContacts(cache.contact.arrSearch);"
-                    on-select="cacheContact($item);">
-                <editable-ui-select-match
-                        placeholder="Start typing a name or email...">{{$select.selected.label}}</editable-ui-select-match>
-                <editable-ui-select-choices  repeat="contact.id as contact in contacts | filter: $select.search"
-                                             refresh="refreshContacts($select.search)"
-                                             refresh-delay="0">
-                    <div ng-bind="contact.label"></div>
-                    <small ng-bind="contact.description[0]"></small>
-                </editable-ui-select-choices>
-                {{cache.contact.obj[task.target_contact_id[0]].sort_name}}
-            </span>
-        </div>
-        <div class="col-xs-6">
-            <div class="dropdown" uib-dropdown>
-                <a href class="dropdown-toggle {{prefix}}context-menu-toggle pull-right" uib-dropdown-toggle><i class="fa fa-ellipsis-v"></i></a>
-                <ul class="dropdown-menu pull-right" uib-dropdown-menu>
-                    <li><a href ng-click="modalTask(task);"><i class="fa fa-pencil"></i> Edit</a></li>
-                    <li><a href ng-click="modalReminder(task, 'task');"><i class="fa fa-envelope-o"></i> Send reminder</a></li>
-                    <li ng-if="permissions.allowDelete"><a href ng-click="deleteTask(task);"><i class="fa fa-trash-o"></i> Delete</a></li>
-                </ul>
-            </div>
-            Assigned to: <span
-                editable-ui-select="task.assignee_contact_id[0]"
-                e-required="true"
-                ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.assignee_contact_id[0]].id}}"
-                onshow="updateContacts(cache.contact.arrSearch);"
-                onbeforesave="updateTask(task, { assignee_contact_id: [$data] });"
-                on-select="cacheContact($item);">
-                <editable-ui-select-match
-                        placeholder="Start typing a name or email...">{{$select.selected.label}}</editable-ui-select-match>
-                <editable-ui-select-choices  repeat="contact.id as contact in contacts | filter: $select.search"
-                                             refresh="refreshContacts($select.search)"
-                                             refresh-delay="0">
-                    <div ng-bind="contact.label"></div>
-                    <small ng-bind="contact.description[0]"></small>
-                </editable-ui-select-choices>
-                {{cache.contact.obj[task.assignee_contact_id[0]].sort_name}}
-            </span>
-        </div>
-    </header>
-    <div class="row">
-        <div class="col-xs-6">
-            <p class="{{prefix}}task-subject">
-              Due:
-              <time editable-bsdate="task.activity_date_time"
-                onbeforesave="updateTask(task, { activity_date_time: $data });"
-                onshow="dpOpen()"
-                class="editable-small"
-                e-ng-click="dpOpen()"
-                e-is-open="picker.opened"
-                e-show-calendar-button="false"
-                e-datepicker-popup>
-                {{task.activity_date_time | date: 'MMM d'}}
-              </time>
-              <span ng-if="!!task.subject">Subject: </span>
-              <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
-                {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
-              </span>
-            </p>
-        </div>
-        <div class="col-xs-6">
-            <span class="{{prefix}}assignment-type">
-                <span
-                        editable-ui-select="task.case_id"
-                        onshow="updateAssignments(cache.assignment.arrSearch, task.target_contact_id[0]);"
-                        onbeforesave="updateTask(task, { case_id: $data });"
-                        on-select="cacheAssignment($item);">
-                    <editable-ui-select-match
-                            placeholder="Enter search term...">{{$select.selected.label}}</editable-ui-select-match>
-                    <editable-ui-select-choices  repeat="assignment.id as assignment in assignments | filter: $select.search"
-                                                 refresh="refreshAssignments($select.search, task.target_contact_id[0], task.case_id)"
-                                                 refresh-delay="0">
-                        <div ng-bind="assignment.label"></div>
-                    </editable-ui-select-choices>
-                    {{cache.assignmentType.obj[cache.assignment.obj[task.case_id].case_type_id].title}}
-                </span>
-            </span>
-        </div>
+  <header class="row">
+    <div class="col-xs-6">
+      <input type="checkbox" ng-change="changeStatus(task, 2)" ng-disabled="task.completed" ng-model="task.completed" class="{{prefix}}task-checkbox" name="task">
+      <a href class="{{prefix}}task-title" ng-click="modalTask(task);" ng-bind="cache.taskType.obj[task.activity_type_id]"></a>:
+      <span editable-ui-select="task.target_contact_id[0]" e-required="true" ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.target_contact_id[0]].id}}" onbeforesave="updateTask(task, { target_contact_id: [$data] });" onshow="updateContacts(cache.contact.arrSearch);"
+          on-select="cacheContact($item);">
+        <editable-ui-select-match placeholder="Start typing a name or email...">{{$select.selected.label}}</editable-ui-select-match>
+        <editable-ui-select-choices repeat="contact.id as contact in contacts | filter: $select.search" refresh="refreshContacts($select.search)" refresh-delay="0">
+          <div ng-bind="contact.label"></div>
+          <small ng-bind="contact.description[0]"></small>
+        </editable-ui-select-choices>
+        {{cache.contact.obj[task.target_contact_id[0]].sort_name}}
+      </span>
     </div>
-    <div class="row">
+    <div class="col-xs-6">
+      <div class="dropdown" uib-dropdown>
+        <a href class="dropdown-toggle {{prefix}}context-menu-toggle pull-right" uib-dropdown-toggle><i class="fa fa-ellipsis-v"></i></a>
+        <ul class="dropdown-menu pull-right" uib-dropdown-menu>
+          <li><a href ng-click="modalTask(task);"><i class="fa fa-pencil"></i> Edit</a></li>
+          <li><a href ng-click="modalReminder(task, 'task');"><i class="fa fa-envelope-o"></i> Send reminder</a></li>
+          <li ng-if="permissions.allowDelete"><a href ng-click="deleteTask(task);"><i class="fa fa-trash-o"></i> Delete</a></li>
+        </ul>
+      </div>
+      Assigned to:
+      <span editable-ui-select="task.assignee_contact_id[0]" e-required="true" ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.assignee_contact_id[0]].id}}" onshow="updateContacts(cache.contact.arrSearch);" onbeforesave="updateTask(task, { assignee_contact_id: [$data] });"
+          on-select="cacheContact($item);">
+        <editable-ui-select-match placeholder="Start typing a name or email...">{{$select.selected.label}}</editable-ui-select-match>
+        <editable-ui-select-choices repeat="contact.id as contact in contacts | filter: $select.search" refresh="refreshContacts($select.search)" refresh-delay="0">
+          <div ng-bind="contact.label"></div>
+          <small ng-bind="contact.description[0]"></small>
+        </editable-ui-select-choices>
+        {{cache.contact.obj[task.assignee_contact_id[0]].sort_name}}
+        </span>
+    </div>
+  </header>
+  <div class="row">
+    <div class="col-xs-6">
+      <p class="{{prefix}}task-subject">
+        Due:
+        <time editable-bsdate="task.activity_date_time" onbeforesave="updateTask(task, { activity_date_time: $data });" onshow="dpOpen()" class="editable-small" e-ng-click="dpOpen()" e-is-open="picker.opened" e-show-calendar-button="false" e-datepicker-popup>
+          {{task.activity_date_time | date: 'MMM d'}}
+        </time>
+        <span ng-if="!!task.subject">Subject: </span>
+        <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
+          {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
+        </span>
+      </p>
+    </div>
+    <div class="col-xs-6">
+      <span class="{{prefix}}assignment-type">
+        <span editable-ui-select="task.case_id"
+          onshow="updateAssignments(cache.assignment.arrSearch, task.target_contact_id[0]);"
+          onbeforesave="updateTask(task, { case_id: $data });"
+          on-select="cacheAssignment($item);">
+          <editable-ui-select-match placeholder="Enter search term...">
+            {{$select.selected.label}}
+          </editable-ui-select-match>
+          <editable-ui-select-choices
+            repeat="assignment.id as assignment in assignments | filter: $select.search"
+            refresh="refreshAssignments($select.search, task.target_contact_id[0], task.case_id)"
+            refresh-delay="0">
+            <div ng-bind="assignment.label"></div>
+          </editable-ui-select-choices>
+            {{cache.assignmentType.obj[cache.assignment.obj[task.case_id].case_type_id].title}}
+        </span>
+      </span>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-xs-12">
+      <a href ng-click="isCollapsed = !isCollapsed" class="btn btn-collapse">
+        <span
+          class="fa"
+          ng-class="{fa: true, 'fa-chevron-down': !isCollapsed, 'fa-chevron-right': isCollapsed }"
+          aria-hidden="true">
+        </span>
+        Show More
+      </a>
+      <article class="row" uib-collapse="isCollapsed">
         <div class="col-xs-12">
-            <a href ng-click="isCollapsed = !isCollapsed" class="btn btn-collapse"><span
-                    class="fa"
-                    ng-class="{fa: true, 'fa-chevron-down': !isCollapsed, 'fa-chevron-right': isCollapsed }"
-                    aria-hidden="true"></span> Show More</a>
-            <article class="row" uib-collapse="isCollapsed">
-                <div class="col-xs-12">
-                    <div class="{{prefix}}task-more">
-                        <div editable-ta="task.details"
-                             onbeforesave="updateTask(task, { details: ta.$data });"><div ta-bind ng-model="task.details"></div></div>
-                        <p class="{{prefix}}task-contact-source">Created by:&nbsp; <a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.source_contact_id].id}}"><span ng-bind="cache.contact.obj[task.source_contact_id].sort_name"></span></a></p>
-                    </div>
-                </div>
-            </article>
+          <div class="{{prefix}}task-more">
+            <div editable-ta="task.details" onbeforesave="updateTask(task, { details: ta.$data });">
+              <div ta-bind ng-model="task.details"></div>
+            </div>
+            <p class="{{prefix}}task-contact-source">Created by:&nbsp; <a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.source_contact_id].id}}"><span ng-bind="cache.contact.obj[task.source_contact_id].sort_name"></span></a></p>
+          </div>
         </div>
+      </article>
     </div>
+  </div>
 </script>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
@@ -99,8 +99,17 @@
             <div editable-ta="task.details" onbeforesave="updateTask(task, { details: ta.$data });">
               <div ta-bind ng-model="task.details"></div>
             </div>
-            <p class="{{prefix}}task-contact-source">Created by:&nbsp; <a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.source_contact_id].id}}"><span ng-bind="cache.contact.obj[task.source_contact_id].sort_name"></span></a></p>
           </div>
+        </div>
+        <div class="col-xs-8">
+          <p class="{{prefix}}task-contact-source">
+            Created by:&nbsp;
+            <a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.source_contact_id].id}}">
+              <span ng-bind="cache.contact.obj[task.source_contact_id].sort_name"></span>
+            </a>
+            &nbsp;-&nbsp;
+            <span class="{{prefix}}task-status" ng-bind="cache.taskStatus.obj[task.status_id]"></span>
+          </p>
         </div>
       </article>
     </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
@@ -16,7 +16,7 @@
 
 <script type="text/ng-template" id="task.html">
   <header class="row">
-    <div class="col-xs-6">
+    <div class="col-xs-7">
       <input type="checkbox" ng-change="changeStatus(task, 2)" ng-disabled="task.completed" ng-model="task.completed" class="{{prefix}}task-checkbox" name="task">
       <a href class="{{prefix}}task-title" ng-click="modalTask(task);" ng-bind="cache.taskType.obj[task.activity_type_id]"></a>:
       <span editable-ui-select="task.target_contact_id[0]" e-required="true" ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[task.target_contact_id[0]].id}}" onbeforesave="updateTask(task, { target_contact_id: [$data] });" onshow="updateContacts(cache.contact.arrSearch);"
@@ -30,7 +30,7 @@
         {{cache.contact.obj[task.target_contact_id[0]].sort_name}}
       </span>
     </div>
-    <div class="col-xs-6">
+    <div class="col-xs-5">
       <div class="dropdown" uib-dropdown>
         <a href class="dropdown-toggle {{prefix}}context-menu-toggle pull-right" uib-dropdown-toggle><i class="fa fa-ellipsis-v"></i></a>
         <ul class="dropdown-menu pull-right" uib-dropdown-menu>
@@ -53,7 +53,7 @@
     </div>
   </header>
   <div class="row">
-    <div class="col-xs-6">
+    <div class="col-xs-7">
       <p class="{{prefix}}task-subject">
         Due:
         <time editable-bsdate="task.activity_date_time" onbeforesave="updateTask(task, { activity_date_time: $data });" onshow="dpOpen()" class="editable-small" e-ng-click="dpOpen()" e-is-open="picker.opened" e-show-calendar-button="false" e-datepicker-popup>
@@ -67,7 +67,7 @@
         </span>
       </p>
     </div>
-    <div class="col-xs-6">
+    <div class="col-xs-5">
       <span class="{{prefix}}assignment-type">
         <span editable-ui-select="task.case_id"
           onshow="updateAssignments(cache.assignment.arrSearch, task.target_contact_id[0]);"

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
@@ -61,7 +61,7 @@
           {{task.activity_date_time | date: 'MMM d'}}
         </time>
         <span>Subject:</span>
-        <span ng-if="!!task.subject" editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
+        <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
           <i class="fa fa-pencil"></i>
           {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
         </span>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
@@ -26,6 +26,7 @@
           <div ng-bind="contact.label"></div>
           <small ng-bind="contact.description[0]"></small>
         </editable-ui-select-choices>
+        <i class="fa fa-pencil"></i>
         {{cache.contact.obj[task.target_contact_id[0]].sort_name}}
       </span>
     </div>
@@ -46,6 +47,7 @@
           <div ng-bind="contact.label"></div>
           <small ng-bind="contact.description[0]"></small>
         </editable-ui-select-choices>
+        <i class="fa fa-pencil"></i>
         {{cache.contact.obj[task.assignee_contact_id[0]].sort_name}}
         </span>
     </div>
@@ -55,10 +57,12 @@
       <p class="{{prefix}}task-subject">
         Due:
         <time editable-bsdate="task.activity_date_time" onbeforesave="updateTask(task, { activity_date_time: $data });" onshow="dpOpen()" class="editable-small" e-ng-click="dpOpen()" e-is-open="picker.opened" e-show-calendar-button="false" e-datepicker-popup>
+          <i class="fa fa-pencil"></i>
           {{task.activity_date_time | date: 'MMM d'}}
         </time>
         <span ng-if="!!task.subject">Subject: </span>
         <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small">
+          <i class="fa fa-pencil"></i>
           {{(task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '')}}
         </span>
       </p>
@@ -78,7 +82,8 @@
             refresh-delay="0">
             <div ng-bind="assignment.label"></div>
           </editable-ui-select-choices>
-            {{cache.assignmentType.obj[cache.assignment.obj[task.case_id].case_type_id].title}}
+          <i class="fa fa-pencil"></i>
+          {{cache.assignmentType.obj[cache.assignment.obj[task.case_id].case_type_id].title}}
         </span>
       </span>
     </div>
@@ -98,6 +103,7 @@
           <div class="{{prefix}}task-more">
             <div editable-ta="task.details" onbeforesave="updateTask(task, { details: ta.$data });">
               <div ta-bind ng-model="task.details"></div>
+              <i class="fa fa-pencil"></i>
             </div>
           </div>
         </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -162,8 +162,9 @@
         <time editable-bsdate="task.activity_date_time" onbeforesave="updateTask(task, { activity_date_time: $data });" onshow="dpOpen()" class="editable-small stick-to-label" e-ng-click="dpOpen()" e-show-calendar-button="false" e-is-open="picker.opened" e-datepicker-popup>
           <i class="fa fa-pencil"></i>
           {{task.activity_date_time | date: 'MMM d'}}
-        </time> Subject:
-        <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small" e-placeholder="Subject...">
+        </time>
+        <span>Subject:</span>
+        <span ng-if="!!task.subject" editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small" e-placeholder="Subject...">
           <i class="fa fa-pencil"></i>
           {{ (task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '') }}
         </span>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -164,7 +164,7 @@
           {{task.activity_date_time | date: 'MMM d'}}
         </time>
         <span>Subject:</span>
-        <span ng-if="!!task.subject" editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small" e-placeholder="Subject...">
+        <span editable-text="task.subject" onbeforesave="updateTask(task, { subject: $data })" class="editable-small" e-placeholder="Subject...">
           <i class="fa fa-pencil"></i>
           {{ (task.subject | limitTo: 60) + (task.subject.length > 60 ? '...' : '') }}
         </span>


### PR DESCRIPTION
### Issue:
A) Pencil icons were missing form 
1. uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html and 
2. uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
![before](https://cloud.githubusercontent.com/assets/6307362/24500816/b77e1852-1566-11e7-9fe9-2fbf7b766d45.gif)
Note: Similar is the case with tasks list in contact page.

B) The "Created By: ..." block in task is kept inside the task details block  both in task list in contact page and calendar tasks list page, 
![screen shot 2017-03-30 at 3 56 08 pm](https://cloud.githubusercontent.com/assets/6307362/24500925/2a2676e2-1567-11e7-8b09-4df114eaecb1.png)

Which does not match with the task in T&A dashboard as follows:
![screen shot 2017-03-30 at 2 49 16 pm](https://cloud.githubusercontent.com/assets/6307362/24500937/33fabf70-1567-11e7-9884-c642e8fb493e.png)

B) Subject field is not consistent with T&A dashboard tasks in calendar task list and contact task page.

### Solution:
1. Add pencil icons in appropriate editable fields in the above files.
2. Display subject field if no data for subject is  present.
3. Adjust bootstrap grid to display subject editable field in same line.

### Screenshot:
1. Displays pencil icons and subject field is visible even if the value is not preset present with subject label.
Before:
![before](https://cloud.githubusercontent.com/assets/6307362/24500816/b77e1852-1566-11e7-9fe9-2fbf7b766d45.gif)

After:
![untitled-final-iloveimg-compressed](https://cloud.githubusercontent.com/assets/6307362/24543809/a859ae3a-1620-11e7-9b18-d917efc4bb7f.gif)

Note: Similarly, it works with task lists in contact page to match with T&A dashboard tasks tab.

2. Display Subject editable field in same line in calendar task list page.
Before:
![screen shot 2017-03-31 at 8 14 35 pm](https://cloud.githubusercontent.com/assets/6307362/24555021/4a154972-164f-11e7-978e-607eed603759.png)

After:
![screen shot 2017-03-31 at 8 10 08 pm](https://cloud.githubusercontent.com/assets/6307362/24555018/4837cbf2-164f-11e7-80c9-3d0b8891f823.png)

