### PR TITLE
PCHR-1913: Fix ui-select first-click focus

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/documents.html
@@ -20,10 +20,11 @@
                             <label class="col-xs-12 col-sm-3 control-label">Type:</label>
                             <div class="col-xs-12 col-sm-9">
                                 <ui-select
+                                        prevent-animations
                                         multiple
                                         ng-model="filterParams.assignmentType">
-                                    <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
-                                    <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
+                                    <ui-select-match prevent-animations class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
+                                    <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
                                         <div ng-bind-html="type.title | highlight: $select.search"></div>
                                     </ui-select-choices>
                                 </ui-select>
@@ -35,10 +36,11 @@
                             <label class="col-xs-12 col-sm-3 control-label">Status:</label>
                             <div class="col-xs-12 col-sm-9">
                                 <ui-select
+                                        prevent-animations
                                         multiple
                                         ng-model="filterParams.documentStatus">
-                                    <ui-select-match class="ui-select-match" placeholder="Select status...">{{$item.value}}</ui-select-match>
-                                    <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr">
+                                    <ui-select-match prevent-animations class="ui-select-match" placeholder="Select status...">{{$item.value}}</ui-select-match>
+                                    <ui-select-choices prevent-animations class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr">
                                         <div ng-bind-html="status.value | highlight: $select.search"></div>
                                     </ui-select-choices>
                                 </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -12,9 +12,9 @@
           </button>
         </div>
         <div class="col-xs-12 col-sm-6 col-lg-4" ng-if="settings.extEnabled.assignments">
-          <ui-select multiple ng-model="filterParams.assignmentType">
-            <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
-            <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
+          <ui-select prevent-animations multiple ng-model="filterParams.assignmentType">
+            <ui-select-match prevent-animations class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
+            <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
               <div ng-bind-html="type.title | highlight: $select.search"></div>
             </ui-select-choices>
           </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -10,11 +10,11 @@
             Status
           </label>
           <div class="col-xs-12 col-sm-9">
-            <ui-select multiple ng-model="filterParamsHolder.documentStatus">
-              <ui-select-match class="ui-select-match" placeholder="Select status...">
+            <ui-select prevent-animations multiple ng-model="filterParamsHolder.documentStatus">
+              <ui-select-match prevent-animations class="ui-select-match" placeholder="Select status...">
                 {{$item.value}}
               </ui-select-match>
-              <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr">
+              <ui-select-choices prevent-animations class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr">
                 <div ng-bind-html="status.value | highlight: $select.search"></div>
               </ui-select-choices>
             </ui-select>
@@ -86,11 +86,12 @@
                 <div class="col-xs-12 col-sm-10">
                   <div class="input-group">
                     <ui-select
+                      prevent-animations
                       allow-clear
                       ng-model="filterParams.contactId">
-                      <ui-select-match class="ui-select-match"
+                      <ui-select-match prevent-animations class="ui-select-match"
                         placeholder="Search / Filter">{{$select.selected.label}}</ui-select-match>
-                      <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
+                      <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search"
                         refresh-delay="0">
                         <div ng-bind="contact.label"></div>
                         <small ng-bind="contact.description[0]"></small>
@@ -110,10 +111,11 @@
                 <label class="col-xs-12 col-sm-4 control-label">Assignment Type:</label>
                 <div class="col-xs-12 col-sm-8">
                   <ui-select
+                    prevent-animations
                     multiple
                     ng-model="filterParams.assignmentType">
-                    <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
-                    <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
+                    <ui-select-match prevent-animations class="ui-select-match" placeholder="Select assignment...">{{$item.title}}</ui-select-match>
+                    <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
                       <div ng-bind-html="type.title | highlight: $select.search"></div>
                     </ui-select-choices>
                   </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/key-dates.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/key-dates.html
@@ -71,10 +71,11 @@
                                         <label class="col-xs-12 col-sm-2 control-label">Date Type:</label>
                                         <div class="col-xs-12 col-sm-10">
                                             <ui-select
+                                                    prevent-animations
                                                     multiple
                                                     ng-model="filterParams.dateType">
-                                                <ui-select-match class="ui-select-match" placeholder="Select date type...">{{$item.value}}</ui-select-match>
-                                                <ui-select-choices class="ui-select-choices" repeat="type.key as type in cache.dateType.arr">
+                                                <ui-select-match prevent-animations class="ui-select-match" placeholder="Select date type...">{{$item.value}}</ui-select-match>
+                                                <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.key as type in cache.dateType.arr">
                                                     <div ng-bind-html="type.value | highlight: $select.search"></div>
                                                 </ui-select-choices>
                                             </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -54,11 +54,11 @@
                     <label class="col-xs-12 col-sm-2 control-label">Contact:</label>
                     <div class="col-xs-12 col-sm-10">
                       <div class="input-group">
-                        <ui-select allow-clear ng-model="filterParams.contactId">
-                          <ui-select-match class="ui-select-match" placeholder="Search / Filter">
+                        <ui-select prevent-animations allow-clear ng-model="filterParams.contactId">
+                          <ui-select-match prevent-animations class="ui-select-match" placeholder="Search / Filter">
                             {{$select.selected.label}}
                           </ui-select-match>
-                          <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search" refresh-delay="0">
+                          <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in cache.contact.arrSearch | filter: $select.search" refresh-delay="0">
                             <div ng-bind="contact.label"></div>
                             <small ng-bind="contact.description[0]"></small>
                           </ui-select-choices>
@@ -77,10 +77,10 @@
                   <div class="form-group">
                     <label class="col-xs-12 col-sm-4 control-label">Assignment Type:</label>
                     <div class="col-xs-12 col-sm-8">
-                      <ui-select multiple ng-model="filterParams.assignmentType">
-                        <ui-select-match class="ui-select-match" placeholder="Select assignment...">{{$item.title}}
+                      <ui-select prevent-animations multiple ng-model="filterParams.assignmentType">
+                        <ui-select-match prevent-animations class="ui-select-match" placeholder="Select assignment...">{{$item.title}}
                         </ui-select-match>
-                        <ui-select-choices class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
+                        <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.id as type in cache.assignmentType.arr">
                           <div ng-bind-html="type.title | highlight: $select.search"></div>
                         </ui-select-choices>
                       </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
@@ -13,11 +13,11 @@
         <div class="row separately">
           <label class="col-xs-12 col-sm-3 control-label required-field-indicator">Target Contact:</label>
           <div ng-if="showCId" class="col-xs-12 col-sm-6">
-            <ui-select allow-clear name="contact" theme="civihr-ui-select" ng-model="assignment.contact_id" ng-change="assignment.client_id=assignment.contact_id" on-select="cacheContact($item)" ng-required="true">
-              <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">
+            <ui-select prevent-animations allow-clear name="contact" theme="civihr-ui-select" ng-model="assignment.contact_id" ng-change="assignment.client_id=assignment.contact_id" on-select="cacheContact($item)" ng-required="true">
+              <ui-select-match prevent-animations class="ui-select-match" placeholder="Start typing a name or email...">
                 {{$select.selected.label}}
               </ui-select-match>
-              <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in contacts.target | filter: $select.search" refresh="refreshContacts($select.search, 'target')" refresh-delay="0">
+              <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in contacts.target | filter: $select.search" refresh="refreshContacts($select.search, 'target')" refresh-delay="0">
                 <div ng-bind="contact.label"></div>
                 <small ng-bind="contact.description[0]"></small>
               </ui-select-choices>
@@ -58,11 +58,11 @@
             Select Task List:
           </label>
           <div class="col-xs-12 col-sm-5">
-            <ui-select ng-model="activitySet" theme="civihr-ui-select" ng-required="true" search-enabled="false" on-select="updateTimeline($item)">
-              <ui-select-match class="ui-select-match" placeholder="- select -">
+            <ui-select prevent-animations ng-model="activitySet" theme="civihr-ui-select" ng-required="true" search-enabled="false" on-select="updateTimeline($item)">
+              <ui-select-match prevent-animations class="ui-select-match" placeholder="- select -">
                 {{$select.selected.label}}
               </ui-select-match>
-              <ui-select-choices class="ui-select-choices" repeat="value.id as value in cache.assignmentType.obj[assignment.case_type_id].definition.activitySets">
+              <ui-select-choices prevent-animations class="ui-select-choices" repeat="value.id as value in cache.assignmentType.obj[assignment.case_type_id].definition.activitySets">
                 <div ng-bind="value.label"></div>
               </ui-select-choices>
             </ui-select>
@@ -104,21 +104,21 @@
                     {{activity.name}}
                   </td>
                   <td colspan="2" ng-if="activity.isAdded">
-                    <ui-select ng-model="activity.activity_type_id" ng-required="!isDisabled && activity.create" theme="civihr-ui-select" class="required-field-indicator">
-                      <ui-select-match class="ui-select-match" placeholder="Select task type">
+                    <ui-select prevent-animations ng-model="activity.activity_type_id" ng-required="!isDisabled && activity.create" theme="civihr-ui-select" class="required-field-indicator">
+                      <ui-select-match prevent-animations class="ui-select-match" placeholder="Select task type">
                         {{ ($select.selected.value.length > 30)? ($select.selected.value | limitTo:30) + '...' : $select.selected.value }}
                       </ui-select-match>
-                      <ui-select-choices class="ui-select-choices" repeat="type.key as type in cache.taskType.arr | filter: $select.search">
+                      <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.key as type in cache.taskType.arr | filter: $select.search">
                         <div ng-bind="type.value"></div>
                       </ui-select-choices>
                     </ui-select>
                   </td>
                   <td>
-                    <ui-select allow-clear theme="civihr-ui-select" ng-model="activity.assignee_contact_id[0]" ng-disabled="isDisabled || !activity.create" on-select="cacheContact($item)">
-                      <ui-select-match class="ui-select-match" placeholder="- select contact -">
+                    <ui-select prevent-animations allow-clear theme="civihr-ui-select" ng-model="activity.assignee_contact_id[0]" ng-disabled="isDisabled || !activity.create" on-select="cacheContact($item)">
+                      <ui-select-match prevent-animations class="ui-select-match" placeholder="- select contact -">
                         {{ ($select.selected.label.length > 25)? ($select.selected.label | limitTo:25) + '...' : $select.selected.label }}
                       </ui-select-match>
-                      <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in contacts.task[$index] | filter: $select.search" refresh="refreshContacts($select.search, 'task', $index)" refresh-delay="0">
+                      <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in contacts.task[$index] | filter: $select.search" refresh="refreshContacts($select.search, 'task', $index)" refresh-delay="0">
                         <div ng-bind="contact.label"></div>
                         <small ng-bind="contact.description[0]"></small>
                       </ui-select-choices>
@@ -186,21 +186,21 @@
                     {{activity.name}}
                   </td>
                   <td colspan="2" ng-if="activity.isAdded">
-                    <ui-select ng-model="activity.activity_type_id" ng-required="true" theme="civihr-ui-select" class="required-field-indicator">
-                      <ui-select-match class="ui-select-match" placeholder="Select document type">
+                    <ui-select prevent-animations ng-model="activity.activity_type_id" ng-required="true" theme="civihr-ui-select" class="required-field-indicator">
+                      <ui-select-match prevent-animations class="ui-select-match" placeholder="Select document type">
                         {{ ($select.selected.value.length > 30)? ($select.selected.value | limitTo:30) + '...' : $select.selected.value }}
                       </ui-select-match>
-                      <ui-select-choices class="ui-select-choices" repeat="type.key as type in cache.documentType.arr | filter: $select.search">
+                      <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.key as type in cache.documentType.arr | filter: $select.search">
                         <div ng-bind="type.value"></div>
                       </ui-select-choices>
                     </ui-select>
                   </td>
                   <td>
-                    <ui-select allow-clear theme="civihr-ui-select" ng-model="activity.assignee_contact_id[0]" ng-disabled="isDisabled || !activity.create" ng-required="!isDisabled && activity.create" on-select="cacheContact($item)">
-                      <ui-select-match class="ui-select-match" placeholder="- select contact -">
+                    <ui-select prevent-animations allow-clear theme="civihr-ui-select" ng-model="activity.assignee_contact_id[0]" ng-disabled="isDisabled || !activity.create" ng-required="!isDisabled && activity.create" on-select="cacheContact($item)">
+                      <ui-select-match prevent-animations class="ui-select-match" placeholder="- select contact -">
                         {{ ($select.selected.label.length > 25)? ($select.selected.label | limitTo:25) + '...' : $select.selected.label }}
                       </ui-select-match>
-                      <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in contacts.document[$index] | filter: $select.search" refresh="refreshContacts($select.search, 'document', $index)" refresh-delay="0">
+                      <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in contacts.document[$index] | filter: $select.search" refresh="refreshContacts($select.search, 'document', $index)" refresh-delay="0">
                         <div ng-bind="contact.label"></div>
                         <small ng-bind="contact.description[0]"></small>
                       </ui-select-choices>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -11,11 +11,11 @@
       <!-- Search and select by name and email -->
       <div class="row">
         <div class="col-xs-12">
-          <ui-select name="target" theme="civihr-ui-select" allow-clear class="required-field-indicator" ng-model="document.target_contact_id[0]" on-select="cacheContact($item)" ng-required="true">
-            <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">
+          <ui-select prevent-animations name="target" theme="civihr-ui-select" allow-clear class="required-field-indicator" ng-model="document.target_contact_id[0]" on-select="cacheContact($item)" ng-required="true">
+            <ui-select-match prevent-animations class="ui-select-match" placeholder="Start typing a name or email...">
               {{$select.selected.label}}
             </ui-select-match>
-            <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in contacts.target | filter: $select.search" refresh="refreshContacts($select.search, 'target')" refresh-delay="0">
+            <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in contacts.target | filter: $select.search" refresh="refreshContacts($select.search, 'target')" refresh-delay="0">
               <div ng-bind="contact.label"></div>
               <small ng-bind="contact.description[0]"></small>
             </ui-select-choices>
@@ -26,11 +26,11 @@
       <div class="row">
         <div class="col-xs-12">
           <div class="crm_custom-select crm_custom-select--full">
-            <ui-select theme="civihr-ui-select" ng-model="document.activity_type_id" class="required-field-indicator" ng-required="true">
-              <ui-select-match allow-clear class="ui-select-match" placeholder="Select document type">
+            <ui-select prevent-animations theme="civihr-ui-select" ng-model="document.activity_type_id" class="required-field-indicator" ng-required="true">
+              <ui-select-match prevent-animations allow-clear class="ui-select-match" placeholder="Select document type">
                 {{$select.selected.value}}
               </ui-select-match>
-              <ui-select-choices class="ui-select-choices" repeat="type.key as type in cache.documentType.arr | filter: $select.search">
+              <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.key as type in cache.documentType.arr | filter: $select.search">
                 <div ng-bind="type.value"></div>
               </ui-select-choices>
             </ui-select>
@@ -116,10 +116,10 @@
           </span>
         </div>
         <div class="col-xs-12 col-sm-7" ng-show="document.assignee_contact_id[0] || showAssigneeField">
-          <ui-select name="assignee" theme="civihr-ui-select" allow-clear ng-model="document.assignee_contact_id[0]" on-select="cacheContact($item)">
-            <ui-select-match class="ui-select-match" placeholder="Start typing a name or email...">{{$select.selected.label}}
+          <ui-select prevent-animations name="assignee" theme="civihr-ui-select" allow-clear ng-model="document.assignee_contact_id[0]" on-select="cacheContact($item)">
+            <ui-select-match prevent-animations class="ui-select-match" placeholder="Start typing a name or email...">{{$select.selected.label}}
             </ui-select-match>
-            <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in contacts.assignee | filter: $select.search" refresh="refreshContacts($select.search, 'assignee')" refresh-delay="0">
+            <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in contacts.assignee | filter: $select.search" refresh="refreshContacts($select.search, 'assignee')" refresh-delay="0">
               <div ng-bind="contact.label"></div>
               <small ng-bind="contact.description[0]"></small>
             </ui-select-choices>
@@ -132,10 +132,10 @@
           </span>
         </div>
         <div class="col-xs-12 col-sm-5" ng-show="showAssignmentField">
-          <ui-select theme="civihr-ui-select" allow-clear ng-model="document.case_id" on-select="cacheAssignment($item);">
-            <ui-select-match class="ui-select-match" placeholder="Enter search term...">{{$select.selected.label}}
+          <ui-select prevent-animations theme="civihr-ui-select" allow-clear ng-model="document.case_id" on-select="cacheAssignment($item);">
+            <ui-select-match prevent-animations class="ui-select-match" placeholder="Enter search term...">{{$select.selected.label}}
             </ui-select-match>
-            <ui-select-choices class="ui-select-choices" repeat="assignment.id as assignment in assignments" refresh="refreshAssignments($select.search)" refresh-delay="0">
+            <ui-select-choices prevent-animations class="ui-select-choices" repeat="assignment.id as assignment in assignments" refresh="refreshAssignments($select.search)" refresh-delay="0">
               <div>
                 <div ng-class="assignment.label_class">{{assignment.label}}</div>
                 <small>
@@ -161,11 +161,11 @@
           </span>
         </label>
         <div class="col-xs-12 col-sm-7" ng-show="statusFieldVisible()">
-          <ui-select theme="civihr-ui-select" name="documentStatus" allow-clear class="required-field-indicator" ng-model="document.status_id" ng-required="true">
-            <ui-select-match allow-clear class="ui-select-match" placeholder="Set Status">
+          <ui-select prevent-animations theme="civihr-ui-select" name="documentStatus" allow-clear class="required-field-indicator" ng-model="document.status_id" ng-required="true">
+            <ui-select-match prevent-animations allow-clear class="ui-select-match" placeholder="Set Status">
               {{$select.selected.value}}
             </ui-select-match>
-            <ui-select-choices class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr | filter: $select.search">
+            <ui-select-choices prevent-animations class="ui-select-choices" repeat="status.key as status in cache.documentStatus.arr | filter: $select.search">
               <div ng-bind="status.value"></div>
             </ui-select-choices>
           </ui-select>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
@@ -11,11 +11,11 @@
       <!--  Select Target Contact-->
       <div class="row">
         <div class="col-xs-12">
-          <ui-select theme="civihr-ui-select" ng-if="showCId" allow-clear name="target" ng-model="task.target_contact_id[0]" on-select="cacheContact($item)" ng-required="true" class="required-field-indicator">
-            <ui-select-match class="ui-select-match" placeholder="Select Target Contact">
+          <ui-select prevent-animations theme="civihr-ui-select" ng-if="showCId" allow-clear name="target" ng-model="task.target_contact_id[0]" on-select="cacheContact($item)" ng-required="true" class="required-field-indicator">
+            <ui-select-match prevent-animations class="ui-select-match" placeholder="Select Target Contact">
               {{$select.selected.label}}
             </ui-select-match>
-            <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in contacts.target | filter: $select.search" refresh="refreshContacts($select.search, 'target')" refresh-delay="0">
+            <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in contacts.target | filter: $select.search" refresh="refreshContacts($select.search, 'target')" refresh-delay="0">
               <div ng-bind="contact.label"></div>
               <small ng-bind="contact.description[0]"></small>
             </ui-select-choices>
@@ -35,11 +35,11 @@
         </div>
         <div class="col-xs-12 col-sm-6" ng-show="!data.activity_type_id">
           <div class="crm_custom-select crm_custom-select--full">
-            <ui-select theme="civihr-ui-select" ng-model="task.activity_type_id" ng-required="true" class="required-field-indicator">
-              <ui-select-match allow-clear class="ui-select-match" placeholder="Select Task Type">
+            <ui-select prevent-animations theme="civihr-ui-select" ng-model="task.activity_type_id" ng-required="true" class="required-field-indicator">
+              <ui-select-match prevent-animations allow-clear class="ui-select-match" placeholder="Select Task Type">
                 {{$select.selected.value}}
               </ui-select-match>
-              <ui-select-choices class="ui-select-choices" repeat="type.key as type in cache.taskType.arr | filter: $select.search">
+              <ui-select-choices prevent-animations class="ui-select-choices" repeat="type.key as type in cache.taskType.arr | filter: $select.search">
                 <div ng-bind="type.value"></div>
               </ui-select-choices>
             </ui-select>
@@ -90,11 +90,11 @@
           </span>
         </div>
         <div class="col-xs-12 col-sm-6" ng-show="task.assignee_contact_id[0] || showFieldAssignee">
-          <ui-select theme="civihr-ui-select" class="required-field-indicator" allow-clear ng-model="task.assignee_contact_id[0]" on-select="cacheContact($item)">
-            <ui-select-match class="ui-select-match" placeholder="Assignee">
+          <ui-select prevent-animations theme="civihr-ui-select" class="required-field-indicator" allow-clear ng-model="task.assignee_contact_id[0]" on-select="cacheContact($item)">
+            <ui-select-match prevent-animations class="ui-select-match" placeholder="Assignee">
               {{$select.selected.label}}
             </ui-select-match>
-            <ui-select-choices class="ui-select-choices" repeat="contact.id as contact in contacts.assignee | filter: $select.search" refresh="refreshContacts($select.search, 'assignee')" refresh-delay="0">
+            <ui-select-choices prevent-animations class="ui-select-choices" repeat="contact.id as contact in contacts.assignee | filter: $select.search" refresh="refreshContacts($select.search, 'assignee')" refresh-delay="0">
               <div ng-bind="contact.label"></div>
               <small ng-bind="contact.description[0]"></small>
             </ui-select-choices>
@@ -129,14 +129,16 @@
         </div>
         <div class="col-xs-12 col-sm-7" ng-show="(task.case_id || showFieldAssignment) && assignments.length">
           <ui-select
+            prevent-animations
             theme="civihr-ui-select"
             ng-model="task.case_id"
             on-select="cacheAssignment($item);"
             search-enabled="false">
-            <ui-select-match class="ui-select-match" placeholder="Assignment">
+            <ui-select-match prevent-animations class="ui-select-match" placeholder="Assignment">
               {{$select.selected.label}}
             </ui-select-match>
             <ui-select-choices
+              prevent-animations
               class="ui-select-choices"
               repeat="assignment.id as assignment in assignments">
               <div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/taskMigrate.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/taskMigrate.html
@@ -9,17 +9,20 @@
             <div class="col-xs-12 col-sm-8">
                 <div class="input-group">
                     <ui-select
+                            prevent-animations
                             allow-clear
                             ng-model="migrate.from"
                             on-select="cacheContact($item); getActivities($item.id);"
                             ng-required="true">
                         <ui-select-match
+                                prevent-animations
                                 class="ui-select-match"
                                 placeholder="Start typing a name or email...">{{$select.selected.label}}</ui-select-match>
                         <ui-select-choices  class="ui-select-choices"
                                             repeat="contact.id as contact in contacts | filter: $select.search"
                                             refresh="refreshContacts($select.search)"
-                                            refresh-delay="0">
+                                            refresh-delay="0"
+                                            prevent-animations>
                             <div ng-bind="contact.label"></div>
                             <small ng-bind="contact.description[0]"></small>
                         </ui-select-choices>
@@ -37,17 +40,20 @@
             <div class="col-xs-12 col-sm-8">
                 <div class="input-group">
                     <ui-select
+                            prevent-animations
                             allow-clear
                             ng-model="migrate.to"
                             on-select="cacheContact($item)"
                             ng-required="true">
                         <ui-select-match
+                                prevent-animations
                                 class="ui-select-match"
                                 placeholder="Start typing a name or email...">{{$select.selected.label}}</ui-select-match>
                         <ui-select-choices  class="ui-select-choices"
                                             repeat="contact.id as contact in contacts | filter: $select.search"
                                             refresh="refreshContacts($select.search)"
-                                            refresh-delay="0">
+                                            refresh-delay="0"
+                                            prevent-animations>
                             <div ng-bind="contact.label"></div>
                             <small ng-bind="contact.description[0]"></small>
                         </ui-select-choices>


### PR DESCRIPTION
# Problem
When you click any select dropdown in new task or new assignment or new document modal you cannot start typing search queries immediately, you need to click the field again.
It's a problem on the library it self, the problem is related with `ngAnimate`, if we remove `ngAnimate` it works.

- https://github.com/angular-ui/ui-select/issues/1592
- https://github.com/angular-ui/ui-select/issues/1436
- https://github.com/angular-ui/ui-select/issues/1201

# Solution
As a temporary solution until the library fix it, it was added the directive [prevent-animations](https://github.com/civicrm/civihr/blob/staging/org.civicrm.reqangular/src/common/directives/prevent-animations.js) to remove the animation on ui-select elements.

**Before**

![first-click](https://cloud.githubusercontent.com/assets/1280255/23895570/f76bb56c-0884-11e7-9f5c-813e7931b915.gif)


**After**

![kapture 2017-03-14 at 7 06 56](https://cloud.githubusercontent.com/assets/1280255/23895562/e5d81c96-0884-11e7-802f-d4485d90f4d7.gif)
