### PR TITLE
PCHR-2151: New Fields for Documents

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/DAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/DAO/Document.php
@@ -246,11 +246,6 @@ class CRM_Tasksassignments_DAO_Document extends CRM_Activity_BAO_Activity
           'dataPattern' => '',
           'export' => true,
         ) ,
-        /*'source_record_id' => array(
-          'name' => 'source_record_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Source Record') ,
-        ) ,*/
         'activity_type_id' => array(
           'name' => 'activity_type_id',
           'type' => CRM_Utils_Type::T_INT,
@@ -297,53 +292,6 @@ class CRM_Tasksassignments_DAO_Document extends CRM_Activity_BAO_Activity
             'type' => 'Select Date',
           ) ,
         ) ,
-        /*'activity_duration' => array(
-          'name' => 'duration',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Duration') ,
-          'import' => true,
-          'where' => 'civicrm_activity.duration',
-          'headerPattern' => '/(activity.)?duration(s)?$/i',
-          'dataPattern' => '',
-          'export' => true,
-          'html' => array(
-            'type' => 'Text',
-          ) ,
-        ) ,*/
-        /*'activity_location' => array(
-          'name' => 'location',
-          'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Location') ,
-          'maxlength' => 255,
-          'size' => CRM_Utils_Type::HUGE,
-          'import' => true,
-          'where' => 'civicrm_activity.location',
-          'headerPattern' => '/(activity.)?location$/i',
-          'dataPattern' => '',
-          'export' => true,
-          'html' => array(
-            'type' => 'Text',
-          ) ,
-        ) ,*/
-        /*'phone_id' => array(
-          'name' => 'phone_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Phone (called) ID') ,
-          'FKClassName' => 'CRM_Core_DAO_Phone',
-          'html' => array(
-            'type' => 'Autocomplete-Select',
-          ) ,
-        ) ,*/
-        /*'phone_number' => array(
-          'name' => 'phone_number',
-          'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Phone (called) Number') ,
-          'maxlength' => 64,
-          'size' => CRM_Utils_Type::BIG,
-          'html' => array(
-            'type' => 'Text',
-          ) ,
-        ) ,*/
         'activity_details' => array(
           'name' => 'details',
           'type' => CRM_Utils_Type::T_TEXT,
@@ -372,94 +320,9 @@ class CRM_Tasksassignments_DAO_Document extends CRM_Activity_BAO_Activity
             'type' => 'Select',
           ) ,
           'pseudoconstant' => array(
-            //'optionGroupName' => 'activity_status',
             'optionGroupName' => 'document_status',
           )
         ) ,
-        /*'priority_id' => array(
-          'name' => 'priority_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Priority') ,
-          'html' => array(
-            'type' => 'Select',
-          ) ,
-          'pseudoconstant' => array(
-            'optionGroupName' => 'priority',
-          )
-        ) ,*/
-        /*'parent_id' => array(
-          'name' => 'parent_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Parent Activity Id') ,
-          'FKClassName' => 'CRM_Activity_DAO_Activity',
-        ) ,*/
-        /*'activity_is_test' => array(
-          'name' => 'is_test',
-          'type' => CRM_Utils_Type::T_BOOLEAN,
-          'title' => ts('Test') ,
-          'import' => true,
-          'where' => 'civicrm_activity.is_test',
-          'headerPattern' => '/(is.)?test(.activity)?/i',
-          'dataPattern' => '',
-          'export' => true,
-          'html' => array(
-            'type' => 'Select',
-          ) ,
-        ) ,*/
-        /*'activity_medium_id' => array(
-          'name' => 'medium_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Activity Medium') ,
-          'default' => 'NULL',
-          'html' => array(
-            'type' => 'Select',
-          ) ,
-          'pseudoconstant' => array(
-            'optionGroupName' => 'encounter_medium',
-          )
-        ) ,*/
-        /*'is_auto' => array(
-          'name' => 'is_auto',
-          'type' => CRM_Utils_Type::T_BOOLEAN,
-          'title' => ts('Auto') ,
-        ) ,*/
-        /*'relationship_id' => array(
-          'name' => 'relationship_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Relationship Id') ,
-          'default' => 'NULL',
-          'FKClassName' => 'CRM_Contact_DAO_Relationship',
-        ) ,*/
-        /*'is_current_revision' => array(
-          'name' => 'is_current_revision',
-          'type' => CRM_Utils_Type::T_BOOLEAN,
-          'title' => ts('Is this activity a current revision in versioning chain?') ,
-          'import' => true,
-          'where' => 'civicrm_activity.is_current_revision',
-          'headerPattern' => '/(is.)?(current.)?(revision|version(ing)?)/i',
-          'dataPattern' => '',
-          'export' => true,
-          'default' => '1',
-          'html' => array(
-            'type' => 'CheckBox',
-          ) ,
-        ) ,*/
-        /*'original_id' => array(
-          'name' => 'original_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Original Activity ID ') ,
-          'FKClassName' => 'CRM_Activity_DAO_Activity',
-        ) ,*/
-        /*'activity_result' => array(
-          'name' => 'result',
-          'type' => CRM_Utils_Type::T_STRING,
-          'title' => ts('Result') ,
-          'maxlength' => 255,
-          'size' => CRM_Utils_Type::HUGE,
-          'html' => array(
-            'type' => 'Text',
-          ) ,
-        ) ,*/
         'activity_is_deleted' => array(
           'name' => 'is_deleted',
           'type' => CRM_Utils_Type::T_BOOLEAN,
@@ -473,49 +336,6 @@ class CRM_Tasksassignments_DAO_Document extends CRM_Activity_BAO_Activity
             'type' => 'Text',
           ) ,
         ) ,
-        /*'activity_campaign_id' => array(
-          'name' => 'campaign_id',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Campaign') ,
-          'import' => true,
-          'where' => 'civicrm_activity.campaign_id',
-          'headerPattern' => '',
-          'dataPattern' => '',
-          'export' => true,
-          'FKClassName' => 'CRM_Campaign_DAO_Campaign',
-          'html' => array(
-            'type' => 'CheckBox',
-          ) ,
-          'pseudoconstant' => array(
-            'table' => 'civicrm_campaign',
-            'keyColumn' => 'id',
-            'labelColumn' => 'title',
-          )
-        ) ,*/
-        /*'activity_engagement_level' => array(
-          'name' => 'engagement_level',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Engagement Index') ,
-          'import' => true,
-          'where' => 'civicrm_activity.engagement_level',
-          'headerPattern' => '',
-          'dataPattern' => '',
-          'export' => true,
-          'html' => array(
-            'type' => 'Select',
-          ) ,
-          'pseudoconstant' => array(
-            'optionGroupName' => 'engagement_index',
-          )
-        ) ,*/
-        /*'weight' => array(
-          'name' => 'weight',
-          'type' => CRM_Utils_Type::T_INT,
-          'title' => ts('Weight') ,
-          'html' => array(
-            'type' => 'Text',
-          ) ,
-        ) ,*/
       );
     }
     return self::$_fields;
@@ -532,30 +352,12 @@ class CRM_Tasksassignments_DAO_Document extends CRM_Activity_BAO_Activity
     if (!(self::$_fieldKeys)) {
       self::$_fieldKeys = array(
         'id' => 'activity_id',
-        //'source_record_id' => 'source_record_id',
         'activity_type_id' => 'activity_type_id',
-          //'activity_type_id' => 'activity_type_id',
         'subject' => 'activity_subject',
         'date_time' => 'activity_date_time',
-        //'duration' => 'activity_duration',
-        //'location' => 'activity_location',
-        //'phone_id' => 'phone_id',
-        //'phone_number' => 'phone_number',
         'details' => 'activity_details',
         'status_id' => 'activity_status_id',
-        //'priority_id' => 'priority_id',
-        //'parent_id' => 'parent_id',
-        //'is_test' => 'activity_is_test',
-        //'medium_id' => 'activity_medium_id',
-        //'is_auto' => 'is_auto',
-        //'relationship_id' => 'relationship_id',
-        //'is_current_revision' => 'is_current_revision',
-        //'original_id' => 'original_id',
-        //'result' => 'activity_result',
         'is_deleted' => 'activity_is_deleted',
-        //'campaign_id' => 'activity_campaign_id',
-        //'engagement_level' => 'activity_engagement_level',
-        //'weight' => 'weight',
       );
     }
     return self::$_fieldKeys;

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -577,8 +577,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
    *
    * @return bool
    */
-  public function upgrade_1025()
-  {
+  public function upgrade_1025() {
     $this->executeCustomDataFile('xml/activity_custom_fields.xml');
 
     return TRUE;

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -580,6 +580,12 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
   public function upgrade_1025() {
     $this->executeCustomDataFile('xml/activity_custom_fields.xml');
 
+    // set "remind_me" to true for all existing documents
+    civicrm_api3('Document', 'get', [
+      'options' => ['limit' => 0],
+      'api.Document.create' => ['id' => '$value.id', 'remind_me' => 1],
+    ]);
+
     return TRUE;
   }
 

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -460,7 +460,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
    * Install Tasks Assignments 'days_to_create_a_document_clone' setting field.
    * It keeps a number of days to create a document clone before original
    * expiry date.
-   * 
+   *
    * @return {boolean}
    */
   public function upgrade_1020() {
@@ -513,7 +513,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
   /*
    * Set up scheduled job which clones documents on pre-set days before
    * their original expiry date.
-   * 
+   *
    * @see PCHR-1365
    */
   public function upgrade_1022()
@@ -572,6 +572,18 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     return TRUE;
   }
 
+  /**
+   * Add new custom fields for activities
+   *
+   * @return bool
+   */
+  public function upgrade_1025()
+  {
+    $this->executeCustomDataFile('xml/activity_custom_fields.xml');
+
+    return TRUE;
+  }
+
     public function uninstall()
     {
         CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')");
@@ -585,7 +597,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
      * specifically it returns the option group and component id
      *
      * @param  string $component
-     * @return Array
+     * @return array
      */
     private function _fetchActivityTypeParams($component) {
       $componentId = null;

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -690,6 +690,7 @@ function _civicrm_api3_document_getcustomfields() {
     $customFields = civicrm_api3('CustomField', 'get', array(
       'sequential' => 1,
       'custom_group_id' => $customGroup['id'],
+      'return' => array('id', 'name', 'data_type'),
     ));
 
     foreach ($customFields['values'] as $customField) {

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -243,7 +243,7 @@ function _civicrm_api3_document_create_spec(&$params) {
   ];
 
   $metadata = civicrm_api3('CustomField', 'get', [
-    'custom_group_id' => "Activity_Custom_Fields",
+    'custom_group_id' => 'Activity_Custom_Fields',
     'options' => ['limit' => 0],
   ])['values'];
 
@@ -252,6 +252,7 @@ function _civicrm_api3_document_create_spec(&$params) {
     $isCustom = substr($key, 0, 7) === 'custom_';
 
     if ($isCustom && $parent === 'Activity' && isset($param['column_name'])) {
+      // custom field names have the format custom_<id>
       $customFieldId = substr($key, strrpos($key, '_') + 1);
 
       // replace custom data options with their column name

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -243,7 +243,11 @@ function _civicrm_api3_document_create_spec(&$params) {
 
   // replace custom data options with their column name
   foreach ($params as $key => $param) {
-    if (substr($key, 0, 7) === 'custom_' && isset($param['column_name'])) {
+
+    $parent = CRM_Utils_Array::value('extends', $param);
+    $isCustom = substr($key, 0, 7) === 'custom_';
+
+    if ($isCustom && $parent === 'Activity' && isset($param['column_name'])) {
       $name = $param['column_name'];
       $params[$name] = $params[$key];
       $params[$name]['api.aliases'] = $key;

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -217,9 +217,6 @@ function _civicrm_api3_document_create_spec(&$params) {
   $activityFields = _civicrm_api_get_fields('Activity');
   $params = array_merge($params, $activityFields);
 
-  //default for source_contact_id = currently logged in user
-  $params['source_contact_id']['api.default'] = 'user_contact_id';
-
   $params['status_id']['api.aliases'] = ['activity_status'];
 
   $params['assignee_contact_id'] = [
@@ -228,6 +225,7 @@ function _civicrm_api3_document_create_spec(&$params) {
     'type' => 1,
     'FKClassName' => 'CRM_Activity_DAO_ActivityContact',
   ];
+
   $params['target_contact_id'] = [
     'name' => 'target_id',
     'title' => 'Activity Target',
@@ -245,8 +243,12 @@ function _civicrm_api3_document_create_spec(&$params) {
 
   // replace custom data options with their column name
   foreach ($params as $key => $param) {
-    if (substr($key, 0, 7) === 'custom_') {
-      $params[$key]['name'] = $param['column_name'];
+    if (substr($key, 0, 7) === 'custom_' && isset($param['column_name'])) {
+      $name = $param['column_name'];
+      $params[$name] = $params[$key];
+      $params[$name]['api.aliases'] = $key;
+      $params[$name]['name'] = $name;
+      unset($params[$key]);
     }
   }
 }
@@ -506,7 +508,6 @@ function civicrm_api3_document_get($params) {
             $params['return'] = explode(',', $params['return']);
             $params['return'] = array_map('trim', $params['return']);
         }
-        $activityCustomValues = array();
         $customFields = _civicrm_api3_document_getcustomfieldsflipped();
         foreach ($customFields as $key => $value) {
             if (in_array($key, $params['return'])) {

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/activity_custom_fields.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/activity_custom_fields.xml
@@ -35,6 +35,7 @@
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
       <column_name>expire_date</column_name>
+      <in_selector>0</in_selector>
       <custom_group_name>Activity_Custom_Fields</custom_group_name>
     </CustomField>
     <CustomField>
@@ -53,6 +54,49 @@
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
       <column_name>clone_date</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Activity_Custom_Fields</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Valid_From</name>
+      <label>Valid From</label>
+      <data_type>Date</data_type>
+      <html_type>Select Date</html_type>
+      <is_required>0</is_required>
+      <is_searchable>1</is_searchable>
+      <is_search_range>1</is_search_range>
+      <weight>19</weight>
+      <help_pre>When the document is valid from</help_pre>
+      <help_post>When the document is valid from</help_post>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>255</text_length>
+      <date_format>yy-mm-dd</date_format>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>valid_from</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Activity_Custom_Fields</custom_group_name>
+    </CustomField>
+    <CustomField>
+      <name>Remind_Me</name>
+      <label>Remind Me</label>
+      <data_type>Boolean</data_type>
+      <html_type>Radio</html_type>
+      <default_value>0</default_value>
+      <is_required>0</is_required>
+      <is_searchable>0</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>20</weight>
+      <help_pre>Generate a reminder when this document is about to expire</help_pre>
+      <help_post>Generate a reminder when this document is about to expire</help_post>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>remind_me</column_name>
+      <in_selector>0</in_selector>
       <custom_group_name>Activity_Custom_Fields</custom_group_name>
     </CustomField>
   </CustomFields>

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/activity_custom_fields.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/activity_custom_fields.xml
@@ -99,5 +99,25 @@
       <in_selector>0</in_selector>
       <custom_group_name>Activity_Custom_Fields</custom_group_name>
     </CustomField>
+    <CustomField>
+      <name>Document_ID</name>
+      <label>Document ID</label>
+      <data_type>String</data_type>
+      <html_type>Text</html_type>
+      <is_required>0</is_required>
+      <is_searchable>1</is_searchable>
+      <is_search_range>0</is_search_range>
+      <weight>21</weight>
+      <help_pre>The ID of the document, e.g. passport number</help_pre>
+      <help_post>The ID of the document, e.g. passport number</help_post>
+      <is_active>1</is_active>
+      <is_view>0</is_view>
+      <text_length>255</text_length>
+      <note_columns>60</note_columns>
+      <note_rows>4</note_rows>
+      <column_name>document_id</column_name>
+      <in_selector>0</in_selector>
+      <custom_group_name>Activity_Custom_Fields</custom_group_name>
+    </CustomField>
   </CustomFields>
 </CustomData>

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/activity_custom_fields.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/activity_custom_fields.xml
@@ -100,22 +100,22 @@
       <custom_group_name>Activity_Custom_Fields</custom_group_name>
     </CustomField>
     <CustomField>
-      <name>Document_ID</name>
-      <label>Document ID</label>
+      <name>Document_Number</name>
+      <label>Document Number</label>
       <data_type>String</data_type>
       <html_type>Text</html_type>
       <is_required>0</is_required>
       <is_searchable>1</is_searchable>
       <is_search_range>0</is_search_range>
       <weight>5</weight>
-      <help_pre>The ID of the document, e.g. passport number</help_pre>
-      <help_post>The ID of the document, e.g. passport number</help_post>
+      <help_pre>The number of the document, e.g. passport number</help_pre>
+      <help_post>The number of the document, e.g. passport number</help_post>
       <is_active>1</is_active>
       <is_view>0</is_view>
       <text_length>255</text_length>
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
-      <column_name>document_id</column_name>
+      <column_name>document_number</column_name>
       <in_selector>0</in_selector>
       <custom_group_name>Activity_Custom_Fields</custom_group_name>
     </CustomField>

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/activity_custom_fields.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/activity_custom_fields.xml
@@ -65,7 +65,7 @@
       <is_required>0</is_required>
       <is_searchable>1</is_searchable>
       <is_search_range>1</is_search_range>
-      <weight>19</weight>
+      <weight>3</weight>
       <help_pre>When the document is valid from</help_pre>
       <help_post>When the document is valid from</help_post>
       <is_active>1</is_active>
@@ -87,7 +87,7 @@
       <is_required>0</is_required>
       <is_searchable>0</is_searchable>
       <is_search_range>0</is_search_range>
-      <weight>20</weight>
+      <weight>4</weight>
       <help_pre>Generate a reminder when this document is about to expire</help_pre>
       <help_post>Generate a reminder when this document is about to expire</help_post>
       <is_active>1</is_active>
@@ -107,7 +107,7 @@
       <is_required>0</is_required>
       <is_searchable>1</is_searchable>
       <is_search_range>0</is_search_range>
-      <weight>21</weight>
+      <weight>5</weight>
       <help_pre>The ID of the document, e.g. passport number</help_pre>
       <help_post>The ID of the document, e.g. passport number</help_post>
       <is_active>1</is_active>


### PR DESCRIPTION
## Overview
Adds three new fields for documents

- Valid from
- Document Number
- Remind Me

## Before
The only custom fields for documents were expire_date and merge_date.

## After
The three new fields will be added and available in the API explorer.

## Technical Details
The new document fields were added manually and exported using `civix generate:custom-xml --data=14`. I added the new fields to the existing XML since existing fields will be ignored.

It was decided that all existing documents should have "remind me" set to true, so I've added an upgrader for this.

## Comments
Originally "document number" was due to be called "document ID" but since this clashes with the actual ID field I changed it.

This PR targets PCHR-2145 branch as it is part of a larger ticket which will be tested as a whole when all subtickets are complete.

---

- [ ] Tests Pass

I do not have testing set up locally