### PR TITLE
PCHR-2152: Remind Me Functionality

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -77,6 +77,14 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
     $clonedField = static::getCustomFieldName('clone_date');
     $remindMeField = static::getCustomFieldName('remind_me');
 
+    $fieldsRequiredForClone = [
+      'target_contact_id',
+      'activity_type_id',
+      'details',
+      'expire_date',
+      'activity_date_time',
+    ];
+
     $params = [
       $expiryField => ['<=' => $cutOffDate->format('Y-m-d')],
       $clonedField => ['IS NULL' => 1],
@@ -84,7 +92,7 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
       'is_deleted' => 0,
       'status_id' => self::STATUS_APPROVED,
       'options' => ['limit' => 0],
-      'return' => ['target_contact_id', 'activity_type_id', 'details']
+      'return' => $fieldsRequiredForClone
     ];
 
     $result = civicrm_api3('Document', 'get', $params);

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -82,6 +82,7 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
       'is_deleted' => 0,
       'status_id' => self::STATUS_APPROVED,
       'options' => ['limit' => 0],
+      'return' => ["target_contact_id", "activity_type_id", "details"]
     ];
 
     $result = civicrm_api3('Document', 'get', $params);
@@ -97,18 +98,16 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
   protected static function cloneDocument(array $original) {
     $clone = $original;
     $origId = $original['id'];
-    $expiryField = static::getCustomFieldName('expire_date');
 
     $clone['activity_date_time'] = $original['expire_date'];
     $clone['status_id'] = self::STATUS_AWAITING_UPLOAD;
 
-    $fields = [$expiryField, 'expire_date', 'file_count', 'id'];
-    $fields[] = sprintf('%s_%s', $expiryField, $origId); // alternate name
-    foreach ($fields as $field) {
+    $fieldsToUnset = ['id', 'file_count', 'expire_date', 'document_id', 'valid_from'];
+    foreach ($fieldsToUnset as $field) {
       unset($clone[$field]);
     }
 
-    civicrm_api3('Document', 'create', $original);
+    civicrm_api3('Document', 'create', $clone);
 
     // Update original's clone_date' so we know it has been cloned.
     $today = (new DateTime())->format('Y-m-d');
@@ -131,6 +130,7 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
       array_walk($fieldNames, function (&$customField) {
         $customField = $customField['name'];
       });
+      $fieldNames = array_flip($fieldNames);
     }
 
     return CRM_Utils_Array::value($fieldName, $fieldNames);

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -83,6 +83,7 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
       'details',
       'expire_date',
       'activity_date_time',
+      'assignee_contact_id',
     ];
 
     $params = [

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -11,7 +11,7 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
    * Create a new Document based on array-data
    *
    * @param array $params key-value pairs
-   * @return CRM_Tasksassignments_DAO_Document|NULL
+   * @return CRM_Tasksassignments_DAO_Document|NULL|object
    */
   public static function create(&$params) {
     $entityName = 'Document';
@@ -38,118 +38,115 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
   }
 
   /**
-   * Clone documents if there are 'days_to_create_a_document_clone' days or less
-   * before their expire date.
-   * Return a count of cloned documents or NULL if 'days_to_create_a_document_clone'
-   * is zero.
-   * 
-   * @return int|NULL
+   * Clone all approved documents if there are 'days_to_create_a_document_clone'
+   * days or less before their expire date.
+   *
+   * @return int
+   *   Count of cloned documents
    */
   public static function cloneDocuments() {
-    $daysToCreateADocumentClone = self::getDaysToCreateADocumentClone();
-    if (!$daysToCreateADocumentClone) {
+    $daysBeforeExpiryToClone = self::getDaysBeforeExpiryToClone();
+    if (!$daysBeforeExpiryToClone) {
       return NULL;
     }
-    $date = (new DateTime())
-            ->add(new DateInterval('P' . $daysToCreateADocumentClone . 'D'));
-    return self::cloneApprovedDocumentsWithExpireDate($date);
-  }
 
-  /**
-   * Return a 'days_to_create_a_document_clone' value from T&A Settings.
-   * 
-   * @return int
-   */
-  protected static function getDaysToCreateADocumentClone() {
-    $setting = civicrm_api3('TASettings', 'getsingle', array(
-      'sequential' => 1,
-      'fields' => "days_to_create_a_document_clone",
-    ));
-    return !empty($setting['value']) ? $setting['value'] : 0;
-  }
+    $interval = new DateInterval('P' . $daysBeforeExpiryToClone . 'D');
+    $cutOffDate = (new DateTime())->add($interval);
+    $documents = self::getDocumentsToClone($cutOffDate);
 
-  /**
-   * Search for approved Documents having expire date less than given $expireDate
-   * and create their clone.
-   * Return a count of cloned documents.
-   * 
-   * @param DateTime $expireDate
-   * @return int
-   */
-  protected static function cloneApprovedDocumentsWithExpireDate(DateTime $expireDate) {
     $count = 0;
-    $query = "SELECT ac.id, ac.entity_id FROM civicrm_value_activity_custom_fields_11 ac "
-      . "LEFT JOIN civicrm_component c ON c.name = 'CiviDocument' "
-      . "LEFT JOIN civicrm_option_group og ON og.name = 'activity_type' "
-      . "LEFT JOIN civicrm_option_value ov ON ov.option_group_id = og.id AND ov.component_id = c.id "
-      . "LEFT JOIN civicrm_activity a ON a.id = ac.entity_id "
-      . "WHERE DATE(ac.expire_date) <= %1 AND ac.clone_date IS NULL AND a.is_deleted = 0 AND a.status_id = 3 AND ov.component_id = c.id AND a.activity_type_id = ov.value";
-    $params = array(
-      1 => array($expireDate->format('Y-m-d'), 'String'),
-    );
-    $result = CRM_Core_DAO::executeQuery($query, $params);
-    while ($result->fetch()) {
-      $document = civicrm_api3('Document', 'getsingle', array(
-        'id' => $result->entity_id,
-        'return' => 'activity_type_id, activity_date_time, details, status_id, is_deleted, expire_date, case_id, source_contact_id, target_contact_id, assignee_contact_id',
-      ));
-      $clone = self::cloneDocument($document, $result->id);
-      if (!empty($clone['id'])) {
-        $count++;
-      }
+    foreach ($documents as $document) {
+      self::cloneDocument($document);
+      $count++;
     }
+
     return $count;
   }
 
   /**
-   * Clone particular document but with unsetting some fields according to
-   * PCHR-1365 requirements.
-   * 
-   * @param array $document
-   * @param int $expireId
+   * Finds all documents that should be cloned
+   *
+   * @param DateTime $cutOffDate
+   *  Documents with an expiry date less than this will be cloned.
    * @return array
    */
-  protected static function cloneDocument(array $document, $expireId) {
-    if (empty($document['id'])) {
-      return NULL;
-    }
-    $originalId = $document['id'];
-    $expireDateField = self::getExpireDateCustomFieldName();
-    $document['activity_date_time'] = $document[$expireDateField];
-    $document['status_id'] = self::STATUS_AWAITING_UPLOAD;
-    unset($document[$expireDateField]);
-    unset($document[$expireDateField . '_' . $expireId]);
-    unset($document['expire_date']);
-    unset($document['file_count']);
-    unset($document['id']);
-    $clone = civicrm_api3('Document', 'create', $document);
-    if (!empty($clone['id'])) {
-      // Update original document's 'clone_date' with current date
-      // so so we'll know that the document has been already cloned.
-      civicrm_api3('Document', 'create', array(
-        'id' => $originalId,
-        'clone_date' => (new DateTime())->format('Y-m-d'),
-      ));
-    }
-    return $clone;
+  protected static function getDocumentsToClone(DateTime $cutOffDate) {
+    $expiryField = static::getCustomFieldName('expire_date');
+    $clonedField = static::getCustomFieldName('clone_date');
+    $remindMeField = static::getCustomFieldName('remind_me');
+
+    $params = [
+      $expiryField => ['<=' => $cutOffDate->format('Y-m-d')],
+      $clonedField => ['IS NULL' => 1],
+      $remindMeField => 1,
+      'is_deleted' => 0,
+      'status_id' => self::STATUS_APPROVED,
+      'options' => ['limit' => 0],
+    ];
+
+    $result = civicrm_api3('Document', 'get', $params);
+
+    return CRM_Utils_Array::value('values', $result, []);
   }
 
   /**
-   * Return a name of document expire date custom field.
-   * 
-   * @return string
+   * Creates a copy of a document with no attached files
+   *
+   * @param array $original
    */
-  protected static function getExpireDateCustomFieldName() {
-    $customGroup = civicrm_api3('CustomGroup', 'get', array(
-      'sequential' => 1,
-      'name' => 'Activity_Custom_Fields',
-    ));
-    $customField = civicrm_api3('CustomField', 'getsingle', array(
-      'sequential' => 1,
-      'custom_group_id' => $customGroup['id'],
-      'name' => 'expire_date',
-      'return' => array('id', 'name', 'data_type'),
-    ));
-    return 'custom_' . $customField['id'];
+  protected static function cloneDocument(array $original) {
+    $clone = $original;
+    $origId = $original['id'];
+    $expiryField = static::getCustomFieldName('expire_date');
+
+    $clone['activity_date_time'] = $original['expire_date'];
+    $clone['status_id'] = self::STATUS_AWAITING_UPLOAD;
+
+    $fields = [$expiryField, 'expire_date', 'file_count', 'id'];
+    $fields[] = sprintf('%s_%s', $expiryField, $origId); // alternate name
+    foreach ($fields as $field) {
+      unset($clone[$field]);
+    }
+
+    civicrm_api3('Document', 'create', $original);
+
+    // Update original's clone_date' so we know it has been cloned.
+    $today = (new DateTime())->format('Y-m-d');
+    $params = ['id' => $origId, 'clone_date' => $today];
+    civicrm_api3('Document', 'create', $params);
   }
+
+  /**
+   * Gets the custom field name for Documents
+   *
+   * @param string $fieldName
+   *  The human-readable name for the field, e.g. "expiry_date"
+   * @return mixed|null
+   */
+  private static function getCustomFieldName($fieldName) {
+    static $fieldNames;
+
+    if (empty($fieldNames)) {
+      $fieldNames = civicrm_api3('Document', 'getcustomfields');
+      array_walk($fieldNames, function (&$customField) {
+        $customField = $customField['name'];
+      });
+    }
+
+    return CRM_Utils_Array::value($fieldName, $fieldNames);
+  }
+
+  /**
+   * Return a 'days_to_create_a_document_clone' value from T&A Settings.
+   *
+   * @return int
+   */
+  protected static function getDaysBeforeExpiryToClone() {
+    $setting = civicrm_api3('TASettings', 'getsingle', [
+      'fields' => "days_to_create_a_document_clone",
+    ]);
+
+    return CRM_Utils_Array::value('value', $setting, 0);
+  }
+
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -102,7 +102,7 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
     $clone['activity_date_time'] = $original['expire_date'];
     $clone['status_id'] = self::STATUS_AWAITING_UPLOAD;
 
-    $fieldsToUnset = ['id', 'file_count', 'expire_date', 'document_id', 'valid_from'];
+    $fieldsToUnset = ['id', 'file_count', 'expire_date', 'document_number', 'valid_from'];
     foreach ($fieldsToUnset as $field) {
       unset($clone[$field]);
     }

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -242,7 +242,7 @@ function _civicrm_api3_document_create_spec(&$params) {
       'api.default' => 'user_contact_id',
   ];
 
-  $params['id']['title'] = "Document ID";
+  $params['id']['title'] = 'Document ID';
 
   $metadata = civicrm_api3('CustomField', 'get', [
     'custom_group_id' => 'Activity_Custom_Fields',

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -242,6 +242,8 @@ function _civicrm_api3_document_create_spec(&$params) {
       'api.default' => 'user_contact_id',
   ];
 
+  $params['id']['title'] = "Document ID";
+
   $metadata = civicrm_api3('CustomField', 'get', [
     'custom_group_id' => 'Activity_Custom_Fields',
     'options' => ['limit' => 0],

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/DocumentTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/DocumentTest.php
@@ -1,8 +1,5 @@
 <?php
 
-
-require_once 'CiviTest/CiviUnitTestCase.php';
-
 /**
  * Class CRM_Tasksassignments_BAO_DocumentTest
  */
@@ -19,10 +16,6 @@ class CRM_Tasksassignments_BAO_DocumentTest extends CiviUnitTestCase {
       'field' => 'activity_type_id',
     ));
     $this->_documentTypeId = array_shift($documentTypes['values']);
-  }
-
-  function tearDown() {
-    parent::tearDown();
   }
 
   /**
@@ -55,7 +48,7 @@ class CRM_Tasksassignments_BAO_DocumentTest extends CiviUnitTestCase {
     );
     $result = CRM_Tasksassignments_BAO_Document::create($params);
 
-    $this->assertTrue($result instanceof CRM_Tasksassignments_DAO_Document);
+    $this->assertTrue($result instanceof CRM_Activity_DAO_Activity);
     $this->assertEquals($this->_documentTypeId, $result->activity_type_id);
   }
 

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
@@ -1,8 +1,5 @@
 <?php
 
-
-require_once 'CiviTest/CiviUnitTestCase.php';
-
 /**
  * Class CRM_Tasksassignments_BAO_TaskTest
  */
@@ -19,10 +16,6 @@ class CRM_Tasksassignments_BAO_TaskTest extends CiviUnitTestCase {
       'field' => 'activity_type_id',
     ));
     $this->_taskTypeId = array_shift($taskTypes['values']);
-  }
-
-  function tearDown() {
-    parent::tearDown();
   }
 
   /**
@@ -55,7 +48,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends CiviUnitTestCase {
     );
     $result = CRM_Tasksassignments_BAO_Task::create($params);
 
-    $this->assertTrue($result instanceof CRM_Activity_BAO_Activity);
+    $this->assertTrue($result instanceof CRM_Activity_DAO_Activity);
     $this->assertEquals($this->_taskTypeId, $result->activity_type_id);
   }
 

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/DocumentTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/DocumentTest.php
@@ -187,8 +187,8 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
     ]);
     $details1 = 'First sample document details';
     $details2 = 'Second sample document details';
-    $today = (new DateTime())->format('Y-m-d');
-    $tomorrow = (new DateTime('tomorrow'))->format('Y-m-d');
+    $today = date('Y-m-d');
+    $tomorrow = date('Y-m-d', strtotime('tomorrow'));
 
     // document with "remind me" = true
     civicrm_api3('Document', 'create', [

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/DocumentTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/DocumentTest.php
@@ -1,21 +1,21 @@
 <?php
 
-
-require_once 'CiviTest/CiviUnitTestCase.php';
-
 /**
  * Class Api_DocumentTest
  */
 class api_v3_DocumentTest extends CiviUnitTestCase {
-  private $_documentTypeId = null;
 
-  function __construct() {
-    parent::__construct();
-    self::cleanDB();
-  }
+  /**
+   * @var int
+   */
+  private $_documentTypeId;
 
-  function setUp() {
+  /**
+   * Runs installer and sets default document type
+   */
+  public function setUp() {
     parent::setUp();
+    $this->quickCleanup(['civicrm_activity'], TRUE);
     $upgrader = CRM_Tasksassignments_Upgrader::instance();
     $upgrader->install();
 
@@ -26,14 +26,10 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
     $this->_documentTypeId = array_shift($documentTypes['values']);
   }
 
-  function tearDown() {
-    parent::tearDown();
-  }
-
   /**
    * @expectedException CiviCRM_API3_Exception
    */
-  function testCreateDocumentWithNoContacts() {
+  public function testCreateDocumentWithNoContacts() {
     civicrm_api3('Document', 'create', array(
       'activity_type_id' => $this->_documentTypeId,
     ));
@@ -42,7 +38,7 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
   /**
    * @expectedException CiviCRM_API3_Exception
    */
-  function testCreateDocumentWithNoSource() {
+  public function testCreateDocumentWithNoSource() {
     civicrm_api3('Document', 'create', array(
       'activity_type_id' => $this->_documentTypeId,
       'assignee_contact_id' => 1,
@@ -50,21 +46,23 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
     ));
   }
 
-  function testCreateDocumentWithNoAssignee() {
+  public function testCreateDocumentWithNoAssignee() {
     $result = civicrm_api3('Document', 'create', array(
       'activity_type_id' => $this->_documentTypeId,
       'source_contact_id' => 1,
       'target_contact_id' => 2,
     ));
 
-    $this->assertFalse($result['is_error']);
-    $this->assertEquals(1, $result['values'][0]['source_contact_id']);
+    $firstResult = array_pop($result['values']);
+
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $firstResult['source_contact_id']);
   }
 
   /**
    * @expectedException CiviCRM_API3_Exception
    */
-  function testCreateDocumentWithNoTarget() {
+  public function testCreateDocumentWithNoTarget() {
     civicrm_api3('Document', 'create', array(
       'activity_type_id' => $this->_documentTypeId,
       'source_contact_id' => 1,
@@ -79,7 +77,7 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
    * meet 'clonedocuments' logic requirements (their 'expire_date'
    * is less than today date + 'days_to_create_a_document_clone' setting value.
    */
-  function testCreateDocumentClone() {
+  public function testCreateDocumentClone() {
     // Setting 'days_to_create_a_document_clone' to 5.
     civicrm_api3('TASettings', 'set', array(
       'sequential' => 1,
@@ -114,6 +112,7 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
       'target_contact_id' => [$contact['id']],
       'assignee_contact_id' => [$contact['id']],
       'details' => $details1,
+      'remind_me' => 1,
       'activity_date_time' => $dueDate,
       'expire_date' => $expireDate1,
       'status_id' => 3,
@@ -125,6 +124,7 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
       'target_contact_id' => [$contact['id']],
       'assignee_contact_id' => [$contact['id']],
       'details' => $details2,
+      'remind_me' => 1,
       'activity_date_time' => $dueDate,
       'expire_date' => $expireDate2,
       'status_id' => 3,
@@ -136,6 +136,7 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
       'target_contact_id' => [$contact['id']],
       'assignee_contact_id' => [$contact['id']],
       'details' => $details3,
+      'remind_me' => 1,
       'activity_date_time' => $dueDate,
       'expire_date' => $expireDate3,
       'status_id' => 3,
@@ -170,4 +171,65 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
     // cloned document.
     $this->assertEquals(0, $clonedCount['values']);
   }
+
+  /**
+   * Only documents with "remind me" = true should be cloned
+   */
+  public function testRemindMeDocumentClone() {
+    civicrm_api3('TASettings', 'set', [
+      'fields' => ['days_to_create_a_document_clone' => 5],
+    ]);
+
+    $contact = civicrm_api3('Contact', 'create', [
+      'contact_type' => 'Individual',
+      'display_name' => 'First Contact',
+      'email' => 'test1@email3215155.com',
+    ]);
+    $details1 = 'First sample document details';
+    $details2 = 'Second sample document details';
+    $today = (new DateTime())->format('Y-m-d');
+    $tomorrow = (new DateTime('tomorrow'))->format('Y-m-d');
+
+    // document with "remind me" = true
+    civicrm_api3('Document', 'create', [
+      'activity_type_id' => $this->_documentTypeId,
+      'source_contact_id' => $contact['id'],
+      'target_contact_id' => [$contact['id']],
+      'assignee_contact_id' => [$contact['id']],
+      'details' => $details1,
+      'remind_me' => 1,
+      'activity_date_time' => $today,
+      'expire_date' => $tomorrow,
+      'status_id' => 3,
+    ]);
+    // document with "remind me" = false
+    civicrm_api3('Document', 'create', [
+      'activity_type_id' => $this->_documentTypeId,
+      'source_contact_id' => $contact['id'],
+      'target_contact_id' => [$contact['id']],
+      'assignee_contact_id' => [$contact['id']],
+      'details' => $details2,
+      'remind_me' => 0,
+      'activity_date_time' => $today,
+      'expire_date' => $tomorrow,
+      'status_id' => 3,
+    ]);
+
+    $clonedCount = civicrm_api3('Document', 'clonedocuments');
+    $this->assertEquals(1, $clonedCount['values']);
+
+    // Then we check if there is properly cloned Document 1.
+    $params = ['details' => $details1, 'activity_date_time' => $tomorrow];
+    $clonedDocument1 = civicrm_api3('Document', 'get', $params);
+    $this->assertEquals(1, $clonedDocument1['count']);
+
+    // And we check if there is no cloned Document 2.
+    $params = ['details' => $details2, 'activity_date_time' => $tomorrow];
+    $clonedDocument2 = civicrm_api3('Document', 'get', $params);
+    $this->assertEquals(0, $clonedDocument2['count']);
+
+    $clonedCount = civicrm_api3('Document', 'clonedocuments');
+    $this->assertEquals(0, $clonedCount['values']);
+  }
+
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
@@ -1,69 +1,75 @@
 <?php
 
-
-require_once 'CiviTest/CiviUnitTestCase.php';
-
 /**
  * Class Api_TaskTest
  */
 class api_v3_TaskTest extends CiviUnitTestCase {
-  private $_taskTypeId = null;
 
-  function setUp() {
+  /**
+   * @var int
+   */
+  private $_taskTypeId;
+
+  /**
+   * Runs the upgrader and creates task type required for test
+   */
+  public function setUp() {
     parent::setUp();
     $upgrader = CRM_Tasksassignments_Upgrader::instance();
     $upgrader->install();
 
-    // Pick one of Task types.
-    $taskTypes = civicrm_api3('Task', 'getoptions', array(
-      'field' => 'activity_type_id',
-    ));
-    $this->_taskTypeId = array_shift($taskTypes['values']);
-  }
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "activity_type",
+      'component_id' => "CiviTask",
+      'label' => "Sample Task Type",
+    ]);
+    $result = array_pop($result['values']);
 
-  function tearDown() {
-    parent::tearDown();
+    $this->_taskTypeId = $result['value'];
   }
 
   /**
    * @expectedException CiviCRM_API3_Exception
    */
-  function testCreateTaskWithNoContacts() {
-    civicrm_api3('Task', 'create', array(
+  public function testCreateTaskWithNoContacts() {
+    civicrm_api3('Task', 'create', [
       'activity_type_id' => $this->_taskTypeId,
-    ));
+    ]);
   }
 
   /**
    * @expectedException CiviCRM_API3_Exception
    */
-  function testCreateTaskWithNoSource() {
-    civicrm_api3('Task', 'create', array(
+  public function testCreateTaskWithNoSource() {
+    civicrm_api3('Task', 'create', [
       'activity_type_id' => $this->_taskTypeId,
       'assignee_contact_id' => 1,
       'target_contact_id' => 2,
-    ));
+    ]);
   }
 
-  function testCreateTaskWithNoAssignee() {
-    $result = civicrm_api3('Task', 'create', array(
+  public function testCreateTaskWithNoAssignee() {
+    $result = civicrm_api3('Task', 'create', [
       'activity_type_id' => $this->_taskTypeId,
       'source_contact_id' => 1,
       'target_contact_id' => 2,
-    ));
+    ]);
 
-    $this->assertFalse($result['is_error']);
-    $this->assertEquals(1, $result['values'][0]['source_contact_id']);
+    $firstResult = array_pop($result['values']);
+
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $firstResult['source_contact_id']);
   }
 
   /**
    * @expectedException CiviCRM_API3_Exception
    */
-  function testCreateTaskWithNoTarget() {
-    civicrm_api3('Task', 'create', array(
+  public function testCreateTaskWithNoTarget() {
+    civicrm_api3('Task', 'create', [
       'activity_type_id' => $this->_taskTypeId,
       'source_contact_id' => 1,
       'assignee_contact_id' => 2,
-    ));
+    ]);
   }
+
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
@@ -19,13 +19,27 @@ class api_v3_TaskTest extends CiviUnitTestCase {
     $upgrader->install();
 
     $result = civicrm_api3('OptionValue', 'create', [
-      'option_group_id' => "activity_type",
-      'component_id' => "CiviTask",
-      'label' => "Sample Task Type",
+      'option_group_id' => 'activity_type',
+      'component_id' => 'CiviTask',
+      'label' => 'Sample Task Type',
     ]);
     $result = array_pop($result['values']);
 
     $this->_taskTypeId = $result['value'];
+  }
+
+  /**
+   * Remove data created in setUp()
+   */
+  protected function tearDown() {
+    civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'activity_type',
+      'component_id' => 'CiviTask',
+      'value' => $this->_taskTypeId,
+      'api.OptionValue.delete' => ['id' => '$value.id'],
+    ]);
+
+    parent::tearDown();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/bootstrap.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/bootstrap.php
@@ -2,7 +2,12 @@
 
 ini_set('memory_limit', '2G');
 ini_set('safe_mode', 0);
+
 eval(cv('php:boot --level=full -t', 'phpcode'));
+
+define('DRUPAL_ROOT', realpath($GLOBALS["civicrm_root"] . '../../../..'));
+require_once DRUPAL_ROOT . '/includes/bootstrap.inc';
+drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
 
 require_once 'TasksassignmentsTestTrait.php';
 


### PR DESCRIPTION
## Overview
The functionality for cloning documents that are approaching their expiry date is already developed and in use. After adding the "remind me" column in #189 we need to check before cloning if the user has selected that they want to be reminded about the document before cloning it.

## Before
All documents that had an expiry date soon approaching were cloned.

## After
Only documents with "remind me" set to true will be cloned (if their expiry date is approaching).

## Technical Details
- Originally I had to unset all the custom field names (there are 3 variations for each e.g. `expire_date`, `custom_77` & `custom_77_9`) before creating but by using "return" in the get request it limits the field names.

## Comments
- I tried to tidy up by removing raw SQL usage

---

- [x] Tests Pass
