### PR TITLE
PCHR-2216: Redo Upgrade To Add Option Value

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -589,6 +589,14 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     return TRUE;
   }
 
+  /**
+   * Redo upgrade_1020 since a change in the code in v1.6.2 re-purposed it and
+   * it is possible that it the option_value was not created in some cases
+   */
+  public function upgrade_1026() {
+    return $this->upgrade_1020();
+  }
+
     public function uninstall()
     {
         CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')");


### PR DESCRIPTION
## Overview
For installations that started prior to v1.6.2 when they ran the upgrader it would have executed code to add ActivityTypes. However in v1.6.2 this upgrader number was re-purposed to add a setting for tasks and assignments. This setting is missing in staging and production sites, so it appears that this upgrader was skipped. This PR will re-run the upgrader and ensure the setting is created.

## Before
The setting does not exist. If you go to /civicrm/tasksassignments/settings#/ and try to change the "Number of days before Document's expire date when a Document clone should be created:" setting it will appear to have worked, but reloading the page will show it to still be empty.

## After
The setting will exist in the option_value table. You will be able to store the number of days value in  /civicrm/tasksassignments/settings#/

## Technical Details
To see the difference in upgrader purpose [compare 1.6.1 and 1.6.2](https://github.com/compucorp/civihr-tasks-assignments/compare/1.6.1...1.6.2#diff-ba2bb50d26fab0ecbb18fc02628c8cafR490)

---

- [x] Tests Pass
