### PR TITLE
FAR-182: Empty Reminder Emails

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -279,6 +279,10 @@ class CRM_Tasksassignments_Reminder {
         $settings
       );
 
+      if (empty(array_filter($reminderData))) {
+        continue;
+      }
+
       $templateBodyHTML = CRM_Core_Smarty::singleton()->fetchWith('CRM/Tasksassignments/Reminder/DailyReminder.tpl', [
         'reminder' => $reminderData,
         'baseUrl' => CIVICRM_UF_BASEURL,
@@ -435,7 +439,7 @@ class CRM_Tasksassignments_Reminder {
    *
    * @param string $now
    *   Date from where key dates and appraisals should be searched, yyyy-mm-dd
-   * @param type $to
+   * @param string $to
    *   Date until where key dates and appraisals should be searched, yyyy-mm-dd
    *
    * @return string
@@ -447,7 +451,7 @@ class CRM_Tasksassignments_Reminder {
     $keyDatesContacts = CRM_Tasksassignments_KeyDates::getContactIds($now, $to);
     $appraisalsContacts = self::$_relatedExtensions['appraisals']
       ? CRM_Appraisals_Reminder::getContactIds($now, $to)
-      : array();
+      : [];
 
     $contacts = array_merge($adminContacts, $keyDatesContacts, $appraisalsContacts);
 


### PR DESCRIPTION
## Overview
Sending the daily reminder gathers a list of tasks and key dates that should be included in the e-mail. It's possible, however, that a contact can be selected because they're involved in a key date (their birthday, for example) but because of the logic for deciding who can see key date data they would receive an empty e-mail.

## Before
There is no check to see if there is any data to send in the email and it's possible to send empty mails.

## After
There is a check before sending if there is actually any content for the mail.

---

- [ ] Tests Pass
Unfortunately tests were fixed in PCHR-2145-updates-to-documents and this is still waiting to be merged.