### PR TITLE
PCHR-1945: Remove updating of custom document values

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -580,12 +580,6 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
   public function upgrade_1025() {
     $this->executeCustomDataFile('xml/activity_custom_fields.xml');
 
-    // set "remind_me" to true for all existing documents
-    civicrm_api3('Document', 'get', [
-      'options' => ['limit' => 0],
-      'api.Document.create' => ['id' => '$value.id', 'remind_me' => 1],
-    ]);
-
     return TRUE;
   }
 


### PR DESCRIPTION
## Overview
The original plan for the document update ticket was to set "remind me" to true for all existing documents in the database. This is failing on staging so will be removed from the release.

## Before
The updater would set "remind_me" to be true for all existing document

## After
"remind_me" will not be set for existing document

## Technical Details
This is failing on staging because of a timeout. On further investigation it seems the chained API call is creating 2 extra revisions for each document every time it fails. This is a combination of expected behavior (the Activity creation will create a revision) and some bug in our document API code which is also creating another revision. These should be fixed separately, see [PCHR-2227](https://compucorp.atlassian.net/browse/PCHR-2277).

---

- [x] Tests Pass
