### PR TITLE
PCHR-1687: Enable Tasks and Assignments Daily Reminder Job

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -296,7 +296,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
             $dao->description = 'Tasks and Assignments Daily Reminder';
             $dao->api_entity = 'task';
             $dao->api_action = 'senddailyreminder';
-            $dao->is_active = 0;
+            $dao->is_active = 1;
             $dao->save();
         }
 


### PR DESCRIPTION
## Overview
'Tasks and assignments Daily Reminder' job is being installed in a disabled state by default. Requirements for PCHR-1687 state this job should be enabled by default on new CiviHR installations. 

## After
Changed the is_active flag on job creation.

---

- [x] Tests Pass
