### PR TITLE
PCHR-2323: Issues with remind me text

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
@@ -8355,7 +8355,7 @@ define('tasks-assignments/controllers/modal/modal-document',[
           form: false
         };
 
-        $scope.remindMeMessage = 'If you check this box CiviHR will “remind” you that this document needs to be reviewed. CiviHR will do this by creating a copy of  the document with the  status of awaiting upload a number of days or months before the document expires. You can set the date to create the copy. The copy will have the same document  types and set the assignee to be the same assignee as for this original version of the document. You will then see it in your documents list and be able to action renewing the document.';
+        $scope.remindMeMessage = 'If you check this box CiviHR will “remind” you that this document needs to be renewed. CiviHR will do this by creating a copy of the document with a status of awaiting upload a number of days or months before the document expires. You can set the date to create the copy <a target="_blank" href="/civicrm/tasksassignments/settings#/">here</a>. The copy will have the same document type and set the assignee to be the same assignee as for this original version of the document. You will then see it in your documents list and be able to action renewing the document.';
       })();
 
       /**

--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
@@ -57,7 +57,7 @@ define([
           form: false
         };
 
-        $scope.remindMeMessage = 'If you check this box CiviHR will “remind” you that this document needs to be reviewed. CiviHR will do this by creating a copy of  the document with the  status of awaiting upload a number of days or months before the document expires. You can set the date to create the copy. The copy will have the same document  types and set the assignee to be the same assignee as for this original version of the document. You will then see it in your documents list and be able to action renewing the document.';
+        $scope.remindMeMessage = 'If you check this box CiviHR will “remind” you that this document needs to be renewed. CiviHR will do this by creating a copy of the document with a status of awaiting upload a number of days or months before the document expires. You can set the date to create the copy <a target="_blank" href="/civicrm/tasksassignments/settings#/">here</a>. The copy will have the same document type and set the assignee to be the same assignee as for this original version of the document. You will then see it in your documents list and be able to action renewing the document.';
       })();
 
       /**

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
@@ -11,7 +11,7 @@ $input-border-radius:    0;
 
 // Include the original ui-select css + the civihr-ui-select dropdown theme
 @import "../../../../../org.civicrm.shoreditch/scss/bootstrap/vendor/ui-select/ui-select";
-@import "../../../../../org.civicrm.shoreditch/scss/bootstrap/components/civihr-ui-select/civihr-ui-select";
+@import "../../../../../civihr/org.civicrm.bootstrapcivihr/scss/components/civihr-ui-select/civihr-ui-select";
 
 // Customizations specific for T&A
 .civihr-ui-select {


### PR DESCRIPTION
## Overview
In T&A document modal, when clicked help icon next to remind me, a pop up is displayed with information. The information had some typos and link for `here` was missing, this PR addresses those issues.

## Before
![screen shot 2017-06-15 at 3 16 32 pm](https://user-images.githubusercontent.com/6307362/27175024-a67d3886-51dd-11e7-9963-712a694cf9e5.png)

## After
![screen shot 2017-06-15 at 3 14 59 pm](https://user-images.githubusercontent.com/6307362/27174940-72531526-51dd-11e7-9076-e5cb71c8ae9c.png)

## Technical Details
1. Replace (only fixed words are listed)
```js
$scope.remindMeMessage = "... reviewed ... types..."
```
with 
```js
$scope.remindMeMessage = "... renewed ... <a target='_blank' href='/civicrm/tasksassignments/settings#/'>here</a>... type ..."
```
2.  SInce the `civihr-ui-select.scss` files no longer exists in `org.civicrm.shoreditch` extension, the `civihr-ui-select` should be reused form `org.civicrm.bootstrapcivihr` extension. So the following updates needs to be done.
Replace
```js
@import "../../../../../org.civicrm.shoreditch/scss/bootstrap/components/civihr-ui-select/civihr-ui-select";
```
By 
```js
@import "../../../../../civihr/org.civicrm.bootstrapcivihr/scss/components/civihr-ui-select/civihr-ui-select";
```

- [x] Tests Pass
