### PR TITLE
PCHR-2319: Change the modal title to edit document in civi

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
@@ -7531,8 +7531,6 @@ define('tasks-assignments/controllers/document-list',[
           return;
         }
 
-        var ctrl = this;
-
         // Remove resolved documents from the document list
         $scope.list = $filter('filterByStatus')($scope.list, $rootScope.cache.documentStatusResolve, false);
 
@@ -7542,27 +7540,13 @@ define('tasks-assignments/controllers/document-list',[
             'IN': config.status.resolve.DOCUMENT
           }
         }).then(function (documentListResolved) {
-          var contactIds = ctrl.contactIds;
-          var assignmentIds = ctrl.assignmentIds;
-
-          ctrl.collectId(documentListResolved);
-
-          if (contactIds && contactIds.length) {
-            ContactService.get({'IN': contactIds}).then(function (data) {
-              ContactService.updateCache(data);
-            });
-          }
-
-          if (assignmentIds && assignmentIds.length && settings.extEnabled.assignments) {
-            AssignmentService.get({'IN': assignmentIds}).then(function (data) {
-              AssignmentService.updateCache(data);
-            });
-          }
+          DocumentService.cacheContactsAndAssignments(documentListResolved).then(function () {
+            $scope.listResolvedLoaded = true;
+          });
 
           Array.prototype.push.apply($scope.list, documentListResolved);
-          $scope.listResolvedLoaded = true;
         });
-      }.bind(this);
+      };
 
       $scope.deleteDocument = function (document) {
         $dialog.open({

--- a/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
@@ -7534,7 +7534,7 @@ define('tasks-assignments/controllers/document-list',[
         // Remove resolved documents from the document list
         $scope.list = $filter('filterByStatus')($scope.list, $rootScope.cache.documentStatusResolve, false);
 
-        DocumentService.get({
+        return DocumentService.get({
           'target_contact_id': config.CONTACT_ID,
           'status_id': {
             'IN': config.status.resolve.DOCUMENT

--- a/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
@@ -7698,15 +7698,20 @@ define('tasks-assignments/controllers/main',[
     function ($scope, $rootScope, $rootElement, $log, $modal, $q, FileService, config) {
       $log.debug('Controller: MainCtrl');
 
-      $rootScope.modalDocument = function (data, e) {
+      $rootScope.modalDocument = function (modalMode, data, e) {
         e && e.preventDefault();
 
+        modalMode = modalMode || 'new';
         data = data || {};
+
         var modalInstance = $modal.open({
           appendTo: $rootElement.find('div').eq(0),
           templateUrl: config.path.TPL + 'modal/document.html?v=3',
           controller: 'ModalDocumentCtrl',
           resolve: {
+            modalMode: function () {
+              return modalMode;
+            },
             role: function () {
               return 'admin';
             },
@@ -8312,9 +8317,10 @@ define('tasks-assignments/controllers/modal/modal-document',[
   'use strict';
 
   controllers.controller('ModalDocumentCtrl', ['$scope', '$uibModalInstance', '$rootScope', '$rootElement', '$q', '$log', 'role',
-    '$filter', '$uibModal', '$dialog', '$timeout', 'AssignmentService', 'DocumentService', 'ContactService', 'FileService', 'data', 'files', 'config', 'HR_settings',
+    '$filter', '$uibModal', '$dialog', '$timeout', 'AssignmentService', 'DocumentService', 'ContactService', 'FileService', 'data',
+    'files', 'config', 'HR_settings', 'modalMode',
     function ($scope, $modalInstance, $rootScope, $rootElement, $q, $log, role, $filter, $modal, $dialog, $timeout, AssignmentService,
-      DocumentService, ContactService, FileService, data, files, config, HR_settings) {
+      DocumentService, ContactService, FileService, data, files, config, HR_settings, modalMode) {
       $log.debug('Controller: ModalDocumentCtrl');
 
       // Init call
@@ -8327,6 +8333,7 @@ define('tasks-assignments/controllers/modal/modal-document',[
 
         $scope.data = data;
         $scope.role = role || 'admin';
+        $scope.modalTitle = modalMode === 'edit' ? 'Edit Document' : 'New Document';
 
         $scope.document.activity_date_time = $scope.document.activity_date_time ? moment($scope.document.activity_date_time).toDate() : null;
         $scope.document.expire_date = $scope.document.expire_date ? moment($scope.document.expire_date).toDate() : null;

--- a/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
@@ -7698,6 +7698,14 @@ define('tasks-assignments/controllers/main',[
     function ($scope, $rootScope, $rootElement, $log, $modal, $q, FileService, config) {
       $log.debug('Controller: MainCtrl');
 
+      /**
+       * Opens Document Modal based on passed modal mode, role and
+       * list of attachments, document data to Document Modal
+       *
+       * @param {string} modalMode - Mode of the Modal, 'edit' or 'new'
+       * @param {object} data - Document data
+       * @param {object} e - Triggered event
+       */
       $rootScope.modalDocument = function (modalMode, data, e) {
         e && e.preventDefault();
 

--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/document-list.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/document-list.js
@@ -191,7 +191,7 @@ define([
         // Remove resolved documents from the document list
         $scope.list = $filter('filterByStatus')($scope.list, $rootScope.cache.documentStatusResolve, false);
 
-        DocumentService.get({
+        return DocumentService.get({
           'target_contact_id': config.CONTACT_ID,
           'status_id': {
             'IN': config.status.resolve.DOCUMENT

--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/document-list.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/document-list.js
@@ -188,8 +188,6 @@ define([
           return;
         }
 
-        var ctrl = this;
-
         // Remove resolved documents from the document list
         $scope.list = $filter('filterByStatus')($scope.list, $rootScope.cache.documentStatusResolve, false);
 
@@ -199,27 +197,13 @@ define([
             'IN': config.status.resolve.DOCUMENT
           }
         }).then(function (documentListResolved) {
-          var contactIds = ctrl.contactIds;
-          var assignmentIds = ctrl.assignmentIds;
-
-          ctrl.collectId(documentListResolved);
-
-          if (contactIds && contactIds.length) {
-            ContactService.get({'IN': contactIds}).then(function (data) {
-              ContactService.updateCache(data);
-            });
-          }
-
-          if (assignmentIds && assignmentIds.length && settings.extEnabled.assignments) {
-            AssignmentService.get({'IN': assignmentIds}).then(function (data) {
-              AssignmentService.updateCache(data);
-            });
-          }
+          DocumentService.cacheContactsAndAssignments(documentListResolved).then(function () {
+            $scope.listResolvedLoaded = true;
+          });
 
           Array.prototype.push.apply($scope.list, documentListResolved);
-          $scope.listResolvedLoaded = true;
         });
-      }.bind(this);
+      };
 
       $scope.deleteDocument = function (document) {
         $dialog.open({

--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/main.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/main.js
@@ -10,15 +10,20 @@ define([
     function ($scope, $rootScope, $rootElement, $log, $modal, $q, FileService, config) {
       $log.debug('Controller: MainCtrl');
 
-      $rootScope.modalDocument = function (data, e) {
+      $rootScope.modalDocument = function (modalMode, data, e) {
         e && e.preventDefault();
 
+        modalMode = modalMode || 'new';
         data = data || {};
+
         var modalInstance = $modal.open({
           appendTo: $rootElement.find('div').eq(0),
           templateUrl: config.path.TPL + 'modal/document.html?v=3',
           controller: 'ModalDocumentCtrl',
           resolve: {
+            modalMode: function () {
+              return modalMode;
+            },
             role: function () {
               return 'admin';
             },

--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/main.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/main.js
@@ -10,6 +10,14 @@ define([
     function ($scope, $rootScope, $rootElement, $log, $modal, $q, FileService, config) {
       $log.debug('Controller: MainCtrl');
 
+      /**
+       * Opens Document Modal based on passed modal mode, role and
+       * list of attachments, document data to Document Modal
+       *
+       * @param {string} modalMode - Mode of the Modal, 'edit' or 'new'
+       * @param {object} data - Document data
+       * @param {object} e - Triggered event
+       */
       $rootScope.modalDocument = function (modalMode, data, e) {
         e && e.preventDefault();
 

--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
@@ -14,9 +14,10 @@ define([
   'use strict';
 
   controllers.controller('ModalDocumentCtrl', ['$scope', '$uibModalInstance', '$rootScope', '$rootElement', '$q', '$log', 'role',
-    '$filter', '$uibModal', '$dialog', '$timeout', 'AssignmentService', 'DocumentService', 'ContactService', 'FileService', 'data', 'files', 'config', 'HR_settings',
+    '$filter', '$uibModal', '$dialog', '$timeout', 'AssignmentService', 'DocumentService', 'ContactService', 'FileService', 'data',
+    'files', 'config', 'HR_settings', 'modalMode',
     function ($scope, $modalInstance, $rootScope, $rootElement, $q, $log, role, $filter, $modal, $dialog, $timeout, AssignmentService,
-      DocumentService, ContactService, FileService, data, files, config, HR_settings) {
+      DocumentService, ContactService, FileService, data, files, config, HR_settings, modalMode) {
       $log.debug('Controller: ModalDocumentCtrl');
 
       // Init call
@@ -29,6 +30,7 @@ define([
 
         $scope.data = data;
         $scope.role = role || 'admin';
+        $scope.modalTitle = modalMode === 'edit' ? 'Edit Document' : 'New Document';
 
         $scope.document.activity_date_time = $scope.document.activity_date_time ? moment($scope.document.activity_date_time).toDate() : null;
         $scope.document.expire_date = $scope.document.expire_date ? moment($scope.document.expire_date).toDate() : null;

--- a/uk.co.compucorp.civicrm.tasksassignments/js/test/controllers/document-list_test.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/test/controllers/document-list_test.js
@@ -8,26 +8,47 @@ define([
   'use strict';
 
   describe('DocumentListCtrl', function () {
-    var $controller, $rootScope, DocumentService, $scope, $q, deferred;
+    var $controller, $rootScope, DocumentService, $scope;
 
     beforeEach(module('civitasks.appDashboard'));
-    beforeEach(inject(function (_$controller_, _$rootScope_, _DocumentService_, _$q_) {
+    beforeEach(inject(function (_$controller_, _$rootScope_, _DocumentService_) {
       $controller = _$controller_;
       $rootScope = _$rootScope_;
       $scope = $rootScope.$new();
       DocumentService = _DocumentService_;
-      $q = _$q_;
-      deferred = $q.defer();
     }));
+
+    beforeEach(function (){
+      spyOn(DocumentService, 'get').and.callFake(fakePromise([]));
+      spyOn(DocumentService, 'cacheContactsAndAssignments').and.callFake(fakePromise([]));
+    });
 
     describe('init()', function () {
       beforeEach(function () {
-        spyOn(DocumentService, 'cacheContactsAndAssignments').and.returnValue(deferred.promise);
         initController();
       });
 
       it('calls document service to cache contacts and assigments', function () {
         expect(DocumentService.cacheContactsAndAssignments).toHaveBeenCalled();
+      });
+    });
+
+    describe('$scope.loadDocumentsResolved', function () {
+      beforeEach(function () {
+        initController();
+        $scope.loadDocumentsResolved();
+      });
+
+      it('calls document service to document list', function () {
+        expect(DocumentService.get).toHaveBeenCalled();
+      });
+
+      it('calls document service to cache contacts and assignments', function () {
+          expect(DocumentService.cacheContactsAndAssignments).toHaveBeenCalled();
+      });
+
+      it('marks relolved section as loaded', function () {
+        expect($scope.listResolvedLoaded).toBe(true);
       });
     });
 
@@ -37,5 +58,20 @@ define([
         documentList: documentMock.documentList
       });
     }
+
+    /**
+     * Creates a fake promise then call
+     *
+     * @param  {array} data Data to pass to callback function
+     */
+    function fakePromise (data) {
+      return function () {
+        return {
+          then: function (callback) {
+            callback(data);
+          }
+        }
+      };
+    };
   });
 });

--- a/uk.co.compucorp.civicrm.tasksassignments/js/test/controllers/modal/modal-document_test.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/test/controllers/modal/modal-document_test.js
@@ -11,7 +11,7 @@ define([
   'use strict';
 
   describe('ModalDocumentCtrl', function () {
-    var $controller, $rootScope, $filter, $scope, HRSettings, data, role, files, sampleAssignee;
+    var $controller, $rootScope, $filter, $scope, HRSettings, data, role, files, sampleAssignee, modalMode;
 
     beforeEach(module('civitasks.appDashboard'));
     beforeEach(inject(function (_$controller_, _$rootScope_, _$filter_) {
@@ -31,6 +31,7 @@ define([
       data = {};
       files = {};
       role = '';
+      modalMode = '';
     }));
 
     describe('init()', function () {
@@ -41,6 +42,10 @@ define([
 
       it('sets the role as admin by default', function () {
         expect($scope.role).toBe('admin');
+      });
+
+      it('sets the modal title as "New Document" by default', function () {
+        expect($scope.modalTitle).toBe('New Document');
       });
 
       it('corectly formats date time in document', function () {
@@ -174,6 +179,17 @@ define([
       });
     });
 
+    describe('$scope.modalTitle', function () {
+      beforeEach(function () {
+        modalMode = 'edit';
+        initController();
+      });
+
+      it('sets the document modal title to "Edit Document"', function () {
+        expect($scope.modalTitle).toBe('Edit Document');
+      });
+    });
+
     function addAssignee (assignee) {
       $scope.addAssignee(assignee);
     }
@@ -196,6 +212,7 @@ define([
         data: data,
         files: files,
         role: role,
+        modalMode: modalMode,
         HR_settings: HRSettings
       });
     }

--- a/uk.co.compucorp.civicrm.tasksassignments/js/test/controllers/modal/modal-document_test.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/test/controllers/modal/modal-document_test.js
@@ -44,10 +44,6 @@ define([
         expect($scope.role).toBe('admin');
       });
 
-      it('sets the modal title as "New Document" by default', function () {
-        expect($scope.modalTitle).toBe('New Document');
-      });
-
       it('corectly formats date time in document', function () {
         expect($scope.document.activity_date_time).toEqual(new Date(documentMock.document.activity_date_time));
         expect($scope.document.expire_date).toEqual(new Date(documentMock.document.expire_date));
@@ -179,14 +175,26 @@ define([
       });
     });
 
-    describe('$scope.modalTitle', function () {
-      beforeEach(function () {
-        modalMode = 'edit';
-        initController();
+    describe('$scope.modalTitle()', function () {
+      describe('when modalMode is not set', function () {
+        beforeEach(function () {
+          initController();
+        });
+
+        it('sets the modal title as "New Document" by default', function () {
+          expect($scope.modalTitle).toBe('New Document');
+        });
       });
 
-      it('sets the document modal title to "Edit Document"', function () {
-        expect($scope.modalTitle).toBe('Edit Document');
+      describe('when modalMode is edit', function () {
+        beforeEach(function () {
+          modalMode = 'edit';
+          initController();
+        });
+
+        it('sets the document modal title to "Edit Document"', function () {
+          expect($scope.modalTitle).toBe('Edit Document');
+        });
       });
     });
 

--- a/uk.co.compucorp.civicrm.tasksassignments/js/test/services/document_test.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/test/services/document_test.js
@@ -11,13 +11,14 @@ define([
   'use strict';
 
   describe('DocumentService', function () {
-    var AssignmentService, ContactService, DocumentService, $q, deferred, promise;
+    var AssignmentService, ContactService, DocumentService, $q, deferred, config, promise;
 
     beforeEach(module('civitasks.appDashboard'));
-    beforeEach(inject(function (_AssignmentService_, _ContactService_, _DocumentService_, _$q_) {
+    beforeEach(inject(function (_AssignmentService_, _ContactService_, _DocumentService_, _config_, _$q_) {
       AssignmentService = _AssignmentService_;
       ContactService = _ContactService_;
       DocumentService = _DocumentService_;
+      config = _config_;
       $q = _$q_;
       deferred = $q.defer();
     }));
@@ -32,12 +33,13 @@ define([
     describe('cacheContactsAndAssignments()', function () {
       describe('needs to cache the contacts and assignments of the given documents', function () {
         beforeEach(function () {
+          config.CONTACT_ID = '210';
           promise = DocumentService.cacheContactsAndAssignments(documentMock.documentList);
         });
 
         it('calls contact service to get details using contactIds', function () {
           expect(ContactService.get).toHaveBeenCalledWith(jasmine.objectContaining({
-            'IN': ['204', '4', '205', '205', '204', '204', '205', '202', '202', '205', '3', '203', '205', '203', '203']
+            'IN': ['204', '4', '205', '205', '204', '204', '205', '202', '202', '205', '3', '203', '205', '203', '203', '210']
           }));
         });
 

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/documents.html
@@ -126,7 +126,7 @@
 </div>
 
 <script type="text/ng-template" id="document.html">
-    <td><a ng-href="{{urlFile}}" ng-click="(!document.file_count || document.file_count == '0') && modalDocument(document, $event);" ng-bind="cache.documentType.obj[document.activity_type_id]"></a></td>
+    <td><a ng-href="{{urlFile}}" ng-click="(!document.file_count || document.file_count == '0') && modalDocument('edit', document, $event);" ng-bind="cache.documentType.obj[document.activity_type_id]"></a></td>
     <td><a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[document.assignee_contact_id[0]].id}}" ng-bind="cache.contact.obj[document.assignee_contact_id[0]].sort_name"></a></td>
     <td ng-if="settings.extEnabled.assignments" ng-bind="(cache.assignmentType.obj[cache.assignment.obj[document.case_id].case_type_id].title || '-')"></td>
     <td ng-bind="(document.activity_date_time | date: 'dd/MM/yyyy') || '-'"></td>
@@ -149,7 +149,7 @@
             <a href class="dropdown-toggle {{prefix}}context-menu-toggle" uib-dropdown-toggle><i class="fa fa-ellipsis-v"></i></a>
             <ul class="dropdown-menu pull-right" uib-dropdown-menu>
                 <li ng-show="document.file_count && document.file_count != '0'"><a ng-href="{{urlFile}}"><i class="fa fa-download"></i> Download</a></li>
-                <li><a href ng-click="modalDocument(document, $event);"><i class="fa fa-pencil"></i> Edit</a></li>
+                <li><a href ng-click="modalDocument('edit', document, $event);"><i class="fa fa-pencil"></i> Edit</a></li>
                 <li><a href ng-click="modalReminder(document, 'document');"><i class="fa fa-envelope-o"></i> Send reminder</a></li>
                 <li ng-if="permissions.allowDelete"><a href ng-click="deleteDocument(document);"><i class="fa fa-trash-o"></i> Delete</a></li>
             </ul>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.documentList.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.documentList.html
@@ -35,7 +35,7 @@
 </div>
 
 <script type="text/ng-template" id="document.html">
-  <td><a ng-href="{{urlFile}}" ng-click="(!document.file_count || document.file_count == '0') && modalDocument(document, $event);" ng-bind="cache.documentType.obj[document.activity_type_id]"></a></td>
+  <td><a ng-href="{{urlFile}}" ng-click="(!document.file_count || document.file_count == '0') && modalDocument('edit', document, $event);" ng-bind="cache.documentType.obj[document.activity_type_id]"></a></td>
   <td><a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[document.assignee_contact_id[0]].id}}" ng-bind="cache.contact.obj[document.assignee_contact_id[0]].sort_name"></a></td>
   <td ng-if="settings.extEnabled.assignments" ng-bind="(cache.assignmentType.obj[cache.assignment.obj[document.case_id].case_type_id].title || '-')"></td>
   <td ng-bind="(document.activity_date_time | date: 'dd/MM/yyyy') || '-'"></td>
@@ -58,7 +58,7 @@
       <a href class="dropdown-toggle {{prefix}}context-menu-toggle" uib-dropdown-toggle><i class="fa fa-ellipsis-v"></i></a>
       <ul class="dropdown-menu pull-right" uib-dropdown-menu>
         <li ng-show="document.file_count && document.file_count != '0'"><a ng-href="{{urlFile}}"><i class="fa fa-download"></i> Download</a></li>
-        <li><a href ng-click="modalDocument(document, $event);"><i class="fa fa-pencil"></i> Edit</a></li>
+        <li><a href ng-click="modalDocument('edit', document, $event);"><i class="fa fa-pencil"></i> Edit</a></li>
         <li><a href ng-click="modalReminder(document, 'document');"><i class="fa fa-envelope-o"></i> Send reminder</a></li>
         <li ng-if="permissions.allowDelete"><a href ng-click="deleteDocument(document);"><i class="fa fa-trash-o"></i> Delete</a></li>
       </ul>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -167,7 +167,7 @@
   </div>
 </div>
 <script type="text/ng-template" id="document.html">
-  <td><a ng-href="{{urlFile}}" ng-click="(!document.file_count || document.file_count == '0') && modalDocument(document, $event);" ng-bind="cache.documentType.obj[document.activity_type_id]"></a></td>
+  <td><a ng-href="{{urlFile}}" ng-click="(!document.file_count || document.file_count == '0') && modalDocument('edit', document, $event);" ng-bind="cache.documentType.obj[document.activity_type_id]"></a></td>
   <td><a ng-href="{{url.CONTACT+'?reset=1&cid='+cache.contact.obj[document.target_contact_id[0]].contact_id}}" ng-bind="cache.contact.obj[document.target_contact_id[0]].sort_name"></a></td>
   <td ng-if="settings.extEnabled.assignments" ng-bind="(cache.assignmentType.obj[cache.assignment.obj[document.case_id].case_type_id].title || '-')"></td>
   <td ng-bind="(document.activity_date_time | date: 'dd/MM/yyyy') || '-'"></td>
@@ -191,7 +191,7 @@
       <a href class="dropdown-toggle {{prefix}}context-menu-toggle" uib-dropdown-toggle><i class="fa fa-ellipsis-v"></i></a>
       <ul class="dropdown-menu pull-right" uib-dropdown-menu>
         <li ng-show="document.file_count && document.file_count != '0'"><a ng-href="{{urlFile}}"><i class="fa fa-download"></i> Download</a></li>
-        <li><a href ng-click="modalDocument(document, $event);"><i class="fa fa-pencil"></i> Edit</a></li>
+        <li><a href ng-click="modalDocument('edit', document, $event);"><i class="fa fa-pencil"></i> Edit</a></li>
         <li><a href ng-click="modalReminder(document, 'document');"><i class="fa fa-envelope-o"></i> Send reminder</a></li>
         <li ng-if="permissions.allowDelete"><a href ng-click="deleteDocument(document);"><i class="fa fa-trash-o"></i> Delete</a></li>
       </ul>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/document.html
@@ -5,7 +5,7 @@
       <span class="sr-only">Close</span>
     </button>
     <h4 class="modal-title" ng-switch="isRole('admin')">
-      <span ng-switch-when="true">New Document</span>
+      <span ng-switch-when="true">{{modalTitle}}</span>
       <span ng-switch-when="false">{{getDocumentType(document.activity_type_id) || 'Select Document Type'}}</span>
     </h4>
   </div>


### PR DESCRIPTION
## Overview
When admin edits existing document from civi (T&A) - the modal title is 'New document', which is confusing. The title needs to  be changed to be "Edit document".

## Before
![2319-before-iloveimg-compressed](https://user-images.githubusercontent.com/6307362/27275258-54e23e9c-54f6-11e7-8753-c89db7393b4a.gif)

## After
![2319-after](https://user-images.githubusercontent.com/6307362/27275183-0fd41898-54f6-11e7-98a1-92b4b561bb27.gif)

## Technical Details
1. `modalDocument()` in `uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/main.js` needs to be updated to accept the mode the document modal should be opened.
```js
  $rootScope.modalDocument = function (modalMode, data, e) {
        ...
        modalMode = modalMode || 'new';
        data = data || {};

        var modalInstance = $modal.open({
          appendTo: $rootElement.find('div').eq(0),
          templateUrl: config.path.TPL + 'modal/document.html?v=3',
          controller: 'ModalDocumentCtrl',
          resolve: {
            modalMode: function () {
              return modalMode;
            },
            ...
          }
      });
  }
```

2. Use `modalMode` and create a `modalTitle` variable to store the modal title based on `modalMode` in file `uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js`
```js
controllers.controller('ModalDocumentCtrl', [...,  'modalMode',
    function (..., modalMode) {
       ...
       $scope.modalTitle = modalMode === 'edit' ? 'Edit Document' : 'New Document';
       ...
   }
]);
```
4. Update the `modalDocument()` call  to accept modal mode as first parameter in following files
i. views/contact/documents.html
ii. views/dashboard/calendar.documentList.html
iii.views/dashboard/documents.html
iv.views/modal/document.html
form
```js
modalDocument(document, $event);
```
to 
```js
modalDocument('edit', document, $event);
```
### Update:
1. `$scope.loadDocumentsResolved` was not updated while making changes in PR #207 , where functionality to cache document and assignments was moved to document service form document list controler in `document-list.js` and by mistake some of the code was not updated in `$scope.loadDocumentsResolved `.  So, this was fixed in this PR.
Update from
```js
$scope.loadDocumentsResolved = function () {
        if ($scope.listResolvedLoaded) {
          return;
        }

        var ctrl = this;

        // Remove resolved documents from the document list
        $scope.list = $filter('filterByStatus')($scope.list, $rootScope.cache.documentStatusResolve, false);

        DocumentService.get({
          'target_contact_id': config.CONTACT_ID,
          'status_id': {
            'IN': config.status.resolve.DOCUMENT
          }
        }).then(function (documentListResolved) {
          var contactIds = ctrl.contactIds;
          var assignmentIds = ctrl.assignmentIds;

          ctrl.collectId(documentListResolved);

          if (contactIds && contactIds.length) {
            ContactService.get({'IN': contactIds}).then(function (data) {
              ContactService.updateCache(data);
            });
          }

          if (assignmentIds && assignmentIds.length && settings.extEnabled.assignments) {
            AssignmentService.get({'IN': assignmentIds}).then(function (data) {
              AssignmentService.updateCache(data);
            });
          }

          Array.prototype.push.apply($scope.list, documentListResolved);
          $scope.listResolvedLoaded = true;
        });
      }.bind(this);
```
to 
```js
$scope.loadDocumentsResolved = function () {
        if ($scope.listResolvedLoaded) {
          return;
        }

        // Remove resolved documents from the document list
        $scope.list = $filter('filterByStatus')($scope.list, $rootScope.cache.documentStatusResolve, false);

        DocumentService.get({
          'target_contact_id': config.CONTACT_ID,
          'status_id': {
            'IN': config.status.resolve.DOCUMENT
          }
        }).then(function (documentListResolved) {
          DocumentService.cacheContactsAndAssignments(documentListResolved).then(function () {
            $scope.listResolvedLoaded = true;
          });

          Array.prototype.push.apply($scope.list, documentListResolved);
        });
      };
```
2. Updated test cases for the additional fix in `document-list.js` controller.
- [x] Tests Pass
