### PR TITLE
PCHR-2317: Remove dropdown bar for multiple select in sidebar in T&A

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -12652,3 +12652,6 @@ fieldset[disabled]
 #civitasks .civihr-ui-select.ui-select-multiple:not(.open) .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple:not(.open) .select2-choices::before {
   content: '\f002' !important;
 }
+#civitasks [no-dropdown].ui-select-multiple:after, #cividocuments [no-dropdown].ui-select-multiple:after {
+  display: none;
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
@@ -8657,8 +8657,8 @@ define('tasks-assignments/controllers/modal/modal-document',[
           var notification = CRM.alert(missingRequiredFields.join(', '),
             missingRequiredFields.length === 1 ? 'Required field' : 'Required fields', 'error');
 
-          $timeout(function () {
-            notification && notification.close();
+          notification && $timeout(function () {
+            notification.close();
             notification = null;
           }, 5000);
 

--- a/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/dist/tasks-assignments.min.js
@@ -8656,10 +8656,12 @@ define('tasks-assignments/controllers/modal/modal-document',[
         if (missingRequiredFields.length) {
           var notification = CRM.alert(missingRequiredFields.join(', '),
             missingRequiredFields.length === 1 ? 'Required field' : 'Required fields', 'error');
+
           $timeout(function () {
-            notification.close();
+            notification && notification.close();
             notification = null;
           }, 5000);
+
           return false;
         }
 

--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
@@ -362,8 +362,8 @@ define([
           var notification = CRM.alert(missingRequiredFields.join(', '),
             missingRequiredFields.length === 1 ? 'Required field' : 'Required fields', 'error');
 
-          $timeout(function () {
-            notification && notification.close();
+          notification && $timeout(function () {
+            notification.close();
             notification = null;
           }, 5000);
 

--- a/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/src/tasks-assignments/controllers/modal/modal-document.js
@@ -361,10 +361,12 @@ define([
         if (missingRequiredFields.length) {
           var notification = CRM.alert(missingRequiredFields.join(', '),
             missingRequiredFields.length === 1 ? 'Required field' : 'Required fields', 'error');
+
           $timeout(function () {
-            notification.close();
+            notification && notification.close();
             notification = null;
           }, 5000);
+
           return false;
         }
 

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
@@ -55,3 +55,10 @@ $input-border-radius:    0;
     }
   }
 }
+
+// Do not display dropdown for ui-select-multiple with attribute no-dropdown
+[no-dropdown].ui-select-multiple {
+  &:after {
+    display: none;
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -10,7 +10,7 @@
             Status
           </label>
           <div class="col-xs-12 col-sm-9">
-            <ui-select prevent-animations multiple ng-model="filterParamsHolder.documentStatus">
+            <ui-select prevent-animations multiple ng-model="filterParamsHolder.documentStatus" no-dropdown>
               <ui-select-match prevent-animations class="ui-select-match" placeholder="Select status...">
                 {{$item.value}}
               </ui-select-match>


### PR DESCRIPTION
## Overview
The multiple select of document status in T&A is broken displaying the dropdown bar in the field. This PR removes the  dropdown bar specific to the field.

## Before
<img width="410" alt="screen shot 2017-06-20 at 1 47 24 pm" src="https://user-images.githubusercontent.com/6307362/27330085-b6ad3c12-55d7-11e7-9f84-1315e83e2e8e.png">

## After
<img width="428" alt="screen shot 2017-06-20 at 4 34 55 pm" src="https://user-images.githubusercontent.com/6307362/27330090-ba3d7d56-55d7-11e7-9853-5e7136fb4029.png">

## Technical Details
1. Added `no-dropdown` attribute in ui-select element in `uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html`
```html
  <ui-select ... no-dropdown>
```

2. Now add style to hide the dropdown bar in `uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss` file.
```css
// Do not display dropdown for ui-select-multiple with attribute no-dropdown
[no-dropdown].ui-select-multiple {
  &:after {
    display: none;
  }
}
```

### Update:
1. The modal Controller is being reused in SSP as well. Since the SSP does not have the notification as in T&A, the `var notification = CRM.alert(...)` will be undefined resulting the `.close()` is not a function error. So, modifying the code to check if the notification is available and only call `$timeout(...)` when available as below:

```js
      if (missingRequiredFields.length) {
          var notification = CRM.alert(...);

          notification && $timeout(function () {
            notification.close();
            ...
          }, 5000);
          ...
        }
```