### PR TITLE
PCHR-2414: Only Clone Current Revision of a Document

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Document.php
@@ -92,6 +92,7 @@ class CRM_Tasksassignments_BAO_Document extends CRM_Tasksassignments_DAO_Documen
       $remindMeField => 1,
       'is_deleted' => 0,
       'status_id' => self::STATUS_APPROVED,
+      'is_current_revision' => 1,
       'options' => ['limit' => 0],
       'return' => $fieldsRequiredForClone
     ];

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Assignment.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Assignment.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Assignments Fabricator class
+ */
+class CRM_Tasksassignments_Test_Fabricator_Assignment {
+  private static $defaultParams = [];
+
+  private function setDefaultValues() {
+    self::$defaultParams = [
+      'case_type_id' => self::getOneCaseType(),
+      'subject' => 'A subject ' . ('Y-m-d H:i:s'),
+      'start_date' => ('Y-m-d H:i:s'),
+      'status_id' => 1,
+    ];
+  }
+
+  public static function fabricate($params = []) {
+    self::setDefaultValues();
+    return CRM_Tasksassignments_BAO_Assignment::create(array_merge(self::$defaultParams, $params));
+  }
+
+  private static function getOneCaseType() {
+    $result = civicrm_api3('CaseType', 'get', [
+      'sequential' => 1,
+      'is_active' => 1,
+      'options' => ['limit' => 1],
+    ]);
+
+    return $result['id'];
+  }
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Assignment.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Assignment.php
@@ -6,6 +6,24 @@
 class CRM_Tasksassignments_Test_Fabricator_Assignment {
   private static $defaultParams = [];
 
+  /**
+   * Fabricates an assignment merging given parameters with default minimum
+   * parameters.
+   *
+   * @param array $params
+   *   List of parameters to use to create the Assignment
+   *
+   * @return CRM_Case_BAO_Case
+   */
+  public static function fabricate($params = []) {
+    self::setDefaultValues();
+    return CRM_Tasksassignments_BAO_Assignment::create(array_merge(self::$defaultParams, $params));
+  }
+
+  /**
+   * Creates an array with minimum parameters that should be used to create an
+   * assignment.
+   */
   private function setDefaultValues() {
     self::$defaultParams = [
       'case_type_id' => self::getOneCaseType(),
@@ -15,11 +33,12 @@ class CRM_Tasksassignments_Test_Fabricator_Assignment {
     ];
   }
 
-  public static function fabricate($params = []) {
-    self::setDefaultValues();
-    return CRM_Tasksassignments_BAO_Assignment::create(array_merge(self::$defaultParams, $params));
-  }
-
+  /**
+   * Loads the first case type found in database and returns its ID.
+   *
+   * @return int
+   *   ID of the first case type found
+   */
   private static function getOneCaseType() {
     $result = civicrm_api3('CaseType', 'get', [
       'sequential' => 1,

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Document.php
@@ -1,5 +1,5 @@
 <?php
-use CRM_HRCore_Test_Fabricator_Contact as ContactFbricator;
+use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 
 /**
  * Documents Fabricator class
@@ -8,7 +8,7 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
   private static $defaultParams = [];
 
   private static function setDefaultParameters() {
-    $contact = ContactFbricator::fabricate();
+    $contact = ContactFabricator::fabricate();
 
     self::$defaultParams = [
       'activity_type_id' => self::getTypeID(),
@@ -21,11 +21,27 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
     ];
   }
 
+  /**
+   * Fabricates Document using the BAO.
+   *
+   * @param array $params
+   *   List of parameters to be passed to the BAO call.
+   *
+   * @return CRM_Tasksassignments_DAO_Document|NULL|object
+   */
   public static function fabricate($params) {
     self::setDefaultParameters();
     return CRM_Tasksassignments_BAO_Document::create(array_merge(self::$defaultParams, $params));
   }
 
+  /**
+   * Fabricates Document using an API call.
+   *
+   * @param $params
+   *   List of parameters to be passed to the API call.
+   *
+   * @return array
+   */
   public static function fabricateWithAPI($params) {
     self::setDefaultParameters();
     $result = civicrm_api3(
@@ -37,6 +53,14 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
     return array_shift($result['values']);
   }
 
+  /**
+   * Returns column name for the given custom field name.
+   *
+   * @param $fieldName
+   *
+   * @return string
+   *   Column name of custom field
+   */
   public static function getCustomFieldName($fieldName) {
     static $fieldNames;
 
@@ -50,6 +74,12 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
     return CRM_Utils_Array::value($fieldName, $fieldNames);
   }
 
+  /**
+   * Obtains the ID for the first document type it finds.
+   *
+   * @return int
+   *   ID of the first valid document type found on the database
+   */
   private function getTypeID() {
     $result = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
@@ -61,15 +91,19 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
     return $result['values'][0]['value'];
   }
 
+  /**
+   * Obtains the ID for the first priority it finds.
+   *
+   * @return int
+   *   ID of the first valid priority found on the database
+   */
   private function getPriorityID() {
     $result = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'option_group_id' => 'priority',
       'options' => ['limit' => 1],
-      'component_id' => 'CiviDocument',
     ]);
 
     return $result['values'][0]['value'];
   }
-
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Document.php
@@ -1,0 +1,75 @@
+<?php
+use CRM_HRCore_Test_Fabricator_Contact as ContactFbricator;
+
+/**
+ * Documents Fabricator class
+ */
+class CRM_Tasksassignments_Test_Fabricator_Document {
+  private static $defaultParams = [];
+
+  private static function setDefaultParameters() {
+    $contact = ContactFbricator::fabricate();
+
+    self::$defaultParams = [
+      'activity_type_id' => self::getTypeID(),
+      'activity_date_time' => date('Y-m-d'),
+      'status_id' => CRM_Tasksassignments_BAO_Document::STATUS_AWAITING_UPLOAD,
+      'priority_id' => self::getPriorityID(),
+      'source_contact_id' => $contact['id'],
+      'target_contact_id' => [$contact['id']],
+      'assignee_contact_id' => [$contact['id']],
+    ];
+  }
+
+  public static function fabricate($params) {
+    self::setDefaultParameters();
+    return CRM_Tasksassignments_BAO_Document::create(array_merge(self::$defaultParams, $params));
+  }
+
+  public static function fabricateWithAPI($params) {
+    self::setDefaultParameters();
+    $result = civicrm_api3(
+      'Document',
+      'create',
+      array_merge(self::$defaultParams, $params)
+    );
+
+    return array_shift($result['values']);
+  }
+
+  public static function getCustomFieldName($fieldName) {
+    static $fieldNames;
+
+    if (empty($fieldNames)) {
+      $result = civicrm_api3('Document', 'getcustomfields');
+      foreach ($result as $customFieldName => $data) {
+        $fieldNames[$data['name']] = $customFieldName;
+      }
+    }
+
+    return CRM_Utils_Array::value($fieldName, $fieldNames);
+  }
+
+  private function getTypeID() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'activity_type',
+      'options' => ['limit' => 1],
+      'component_id' => 'CiviDocument',
+    ]);
+
+    return $result['values'][0]['value'];
+  }
+
+  private function getPriorityID() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'priority',
+      'options' => ['limit' => 1],
+      'component_id' => 'CiviDocument',
+    ]);
+
+    return $result['values'][0]['value'];
+  }
+
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Document.php
@@ -7,20 +7,6 @@ use CRM_HRCore_Test_Fabricator_Contact as ContactFabricator;
 class CRM_Tasksassignments_Test_Fabricator_Document {
   private static $defaultParams = [];
 
-  private static function setDefaultParameters() {
-    $contact = ContactFabricator::fabricate();
-
-    self::$defaultParams = [
-      'activity_type_id' => self::getTypeID(),
-      'activity_date_time' => date('Y-m-d'),
-      'status_id' => CRM_Tasksassignments_BAO_Document::STATUS_AWAITING_UPLOAD,
-      'priority_id' => self::getPriorityID(),
-      'source_contact_id' => $contact['id'],
-      'target_contact_id' => [$contact['id']],
-      'assignee_contact_id' => [$contact['id']],
-    ];
-  }
-
   /**
    * Fabricates Document using the BAO.
    *
@@ -54,24 +40,20 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
   }
 
   /**
-   * Returns column name for the given custom field name.
-   *
-   * @param $fieldName
-   *
-   * @return string
-   *   Column name of custom field
+   * Sets default minimum parametrs to create a document.
    */
-  public static function getCustomFieldName($fieldName) {
-    static $fieldNames;
+  private static function setDefaultParameters() {
+    $contact = ContactFabricator::fabricate();
 
-    if (empty($fieldNames)) {
-      $result = civicrm_api3('Document', 'getcustomfields');
-      foreach ($result as $customFieldName => $data) {
-        $fieldNames[$data['name']] = $customFieldName;
-      }
-    }
-
-    return CRM_Utils_Array::value($fieldName, $fieldNames);
+    self::$defaultParams = [
+      'activity_type_id' => self::getTestDocumentTypeID(),
+      'activity_date_time' => date('Y-m-d'),
+      'status_id' => CRM_Tasksassignments_BAO_Document::STATUS_AWAITING_UPLOAD,
+      'priority_id' => self::getTestPriorityID(),
+      'source_contact_id' => $contact['id'],
+      'target_contact_id' => [$contact['id']],
+      'assignee_contact_id' => [$contact['id']],
+    ];
   }
 
   /**
@@ -80,7 +62,7 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
    * @return int
    *   ID of the first valid document type found on the database
    */
-  private function getTypeID() {
+  private function getTestDocumentTypeID() {
     $result = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'option_group_id' => 'activity_type',
@@ -97,7 +79,7 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
    * @return int
    *   ID of the first valid priority found on the database
    */
-  private function getPriorityID() {
+  private function getTestPriorityID() {
     $result = civicrm_api3('OptionValue', 'get', [
       'sequential' => 1,
       'option_group_id' => 'priority',

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/DocumentTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/DocumentTest.php
@@ -335,6 +335,12 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
     $this->assertEquals($expectedCount, $result['count']);
   }
 
+  /**
+   * Obtain number of days before document expiring date configured in system.
+   *
+   * @return int
+   *   Number of days before expiring date
+   */
   private function getDaysBeforeExpiryToClone() {
     $setting = civicrm_api3('TASettings', 'getsingle', [
       'fields' => 'days_to_create_a_document_clone',
@@ -343,6 +349,12 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
     return CRM_Utils_Array::value('value', $setting, 0);
   }
 
+  /**
+   * Set number of days before document expiring date configured in system.
+   *
+   * @param int $days
+   *   Number of days before document expiring date
+   */
   private function setDaysBeforeExpiryToClone($days) {
     civicrm_api3('TASettings', 'set', [
       'fields' => ['days_to_create_a_document_clone' => $days],


### PR DESCRIPTION
## Overview
Every time the Clone documents batch job is executed, it adds redundant clones of the expiring document record.

## Before
Cloning scheduled job was copying all revisions of a document that met cloning criteria, which resulted in duplicates being created each time the job was run. Even though cloned documents were being marked as such, this marking was done on a new revision of the document. Thus, the old revision always met the cloning criteria. The problem was even worse if an approved document was changed, as this would create even more revisions, that would also get cloned.

## After
Fixed by only cloning current revisions of a document, if they meet other cloning criteria.

---

- [x] Tests Pass
