### PR TITLE
PCHR-2277: Don't Create Extra Revisions on Document Updates

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Document.php
@@ -15,7 +15,7 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
    *
    * @return CRM_Tasksassignments_DAO_Document|NULL|object
    */
-  public static function fabricate($params) {
+  public static function fabricate($params = []) {
     self::setDefaultParameters();
     return CRM_Tasksassignments_BAO_Document::create(array_merge(self::$defaultParams, $params));
   }
@@ -28,7 +28,7 @@ class CRM_Tasksassignments_Test_Fabricator_Document {
    *
    * @return array
    */
-  public static function fabricateWithAPI($params) {
+  public static function fabricateWithAPI($params = []) {
     self::setDefaultParameters();
     $result = civicrm_api3(
       'Document',

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -34,8 +34,17 @@ function civicrm_api3_document_create($params) {
     return $errors;
   }
 
+  // Processing for custom data
+  $customFields = _civicrm_api3_document_getcustomfieldsflipped();
+  foreach ($customFields as $key => $value) {
+    if (isset($params[$key])) {
+      $params[$value] = $params[$key];
+    }
+  }
+
   $values = $activityArray = array();
   _civicrm_api3_custom_format_params($params, $values, 'Document');
+  _civicrm_api3_custom_format_params($params, $values, 'Activity');
 
   if (!empty($values['custom'])) {
     $params['custom'] = $values['custom'];
@@ -46,6 +55,11 @@ function civicrm_api3_document_create($params) {
   $case_id           = '';
   $createRevision    = FALSE;
   $oldActivityValues = array();
+
+  // Lookup case id if not supplied
+  if (!isset($params['case_id']) && !empty($params['id'])) {
+    $params['case_id'] = CRM_Core_DAO::singleValueQuery("SELECT case_id FROM civicrm_case_activity WHERE activity_id = " . (int) $params['id']);
+  }
   if (!empty($params['case_id'])) {
     $case_id = $params['case_id'];
     if (!empty($params['id'])) {
@@ -115,20 +129,6 @@ function civicrm_api3_document_create($params) {
   $activityBAO = CRM_Tasksassignments_BAO_Document::create($params);
 
   if (isset($activityBAO->id)) {
-
-    $activityCustomValues = array();
-    $customFields = _civicrm_api3_document_getcustomfieldsflipped();
-    foreach ($customFields as $key => $value) {
-        if (isset($params[$key])) {
-            $activityCustomValues[$value] = $params[$key];
-        }
-    }
-    if (!empty($activityCustomValues)) {
-        civicrm_api3('Activity', 'create', array_merge(
-            array('id' => $activityBAO->id),
-            $activityCustomValues
-        ));
-    }
 
     if ($case_id && !$createRevision) {
       // If this is a brand new case activity we need to add this

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Document.php
@@ -60,6 +60,7 @@ function civicrm_api3_document_create($params) {
   if (!isset($params['case_id']) && !empty($params['id'])) {
     $params['case_id'] = CRM_Core_DAO::singleValueQuery("SELECT case_id FROM civicrm_case_activity WHERE activity_id = " . (int) $params['id']);
   }
+
   if (!empty($params['case_id'])) {
     $case_id = $params['case_id'];
     if (!empty($params['id'])) {

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/DocumentTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/DocumentTest.php
@@ -321,17 +321,22 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
       ]);
     }
 
-    $activityCount = civicrm_api3('Activity', 'getcount');
-    $this->assertEquals(3, $activityCount);
-
-    $this->assertDocumentRevisionCount($documents['standAloneDocument']['id'], 1);
-    $this->assertDocumentRevisionCount($documents['caseDocument']['id'], 2);
+    $this->assertEquals(3, civicrm_api3('Activity', 'getcount'));
+    $this->assertEquals(1, $this->getDocumentRevisionCount($documents['standAloneDocument']['id']));
+    $this->assertEquals(2, $this->getDocumentRevisionCount($documents['caseDocument']['id']));
   }
 
-  private function assertDocumentRevisionCount($documentID, $expectedCount) {
+  /**
+   * Counts total number of revisions for the given document ID.
+   *
+   * @param int $documentID
+   *
+   * @return int
+   *   Number of revisions found for the given document ID
+   */
+  private function getDocumentRevisionCount($documentID) {
     $result = civicrm_api3('Activity', 'get', [
       'sequential' => 1,
-      'activity_type_id' => "VISA",
       'id' => $documentID,
       'original_id' => $documentID,
       'options' => [
@@ -341,7 +346,7 @@ class api_v3_DocumentTest extends CiviUnitTestCase {
       ],
     ]);
 
-    $this->assertEquals($expectedCount, $result['count']);
+    return $result['count'];
   }
 
   /**


### PR DESCRIPTION
## Overview
Updating a document sometimes created one or two revisions. It should behave the same way as activities, only creating revisions if it is set to a case.

## Before
The implementation of create API call to Documents entity was generating up to two revisions per call, when the following conditions were met:

- Params array contained 'case_id'
- Params array contained a custom field

This happened because, first, Document create API generated a new revision from the document's old data, if a value for 'case_id' was found in params array, making any updates on the new revision after. Once the initial updates were done, it checked if there were any custom fields being updated, and if
so, made an API call to Activity's create action to update the document's custom fields. This call also checks for case_id and creates a new revision if it is set in params array, or if the relationship is found in the database for the activity.

## After
The second API call to Activity's create action was probably added because custom fields were not being updated by the call to Document BAO's create method. Now, the reason for this was in order to update custom fields, API expected the physical column names to be used, instead of their field names.

Fixed by replacing custom field names for the column names and looking for custom fields defined for both Documents and Activities, before starting all updates. Also removed the second API call to Activity create action, as it is no longer needed.

With this, API call to Document's create action behaves exactly as Activity's create call, creating only one revision per update for documents assigned to a case.

---

- [x] Tests Pass
