### PR TITLE
PCHR-2464: Additional post-amnesty-merge fixes

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/assignment.html
@@ -31,7 +31,7 @@
           <label class="col-xs-12 col-sm-3 control-label required-field-indicator">Assignment Type:</label>
           <div class="col-xs-12 col-sm-6">
             <div class="crm_custom-select crm_custom-select--full">
-              <select name="assignment" ng-class="{'has-error': assignmentForm.assignment.$invalid}" ng-required="true" class="form-control" ng-change="setData()" ng-model="assignment.case_type_id" ng-options="value.id as value.title for value in cache.assignmentType.arr">
+              <select name="assignment" ng-class="{'has-error': assignmentForm.assignment.$invalid}" ng-required="true" class="form-control no-select2" ng-change="setData()" ng-model="assignment.case_type_id" ng-options="value.id as value.title for value in cache.assignmentType.arr">
                 <option value="">- select -</option>
               </select>
               <span class="crm_custom-select__arrow"></span>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/modal/task.html
@@ -113,7 +113,7 @@
         </div>
         <div class="col-xs-12 col-sm-5" ng-show="task.status_id || showFieldStatus">
           <div class="crm_custom-select crm_custom-select--full">
-            <select ng-required class="form-control" ng-model="task.status_id" ng-options="status.key as status.value for status in cache.taskStatus.arr">
+            <select ng-required class="form-control no-select2" ng-model="task.status_id" ng-options="status.key as status.value for status in cache.taskStatus.arr">
               <option value="">Status</option>
             </select>
             <span class="crm_custom-select__arrow"></span>


### PR DESCRIPTION
## Overview
This PR adds the "class markers" to avoid the [enable-select2.js](https://github.com/civicrm/org.civicrm.shoreditch/blob/master/js/enable-select2.js) and [radio-checkbox.js](https://github.com/civicrm/org.civicrm.shoreditch/blob/master/js/radio-checkbox.js) scripts to the marked radio/select elements, that was resulting in broken styles

## Before
<img width="828" alt="ta-before" src="https://user-images.githubusercontent.com/6400898/29513618-3232a110-8666-11e7-85f2-16a25c32e285.png">

## After
<img width="450" alt="ta-after" src="https://user-images.githubusercontent.com/6400898/29513630-3955ed12-8666-11e7-878e-fd56373f2e87.png">

---

- [x] Tests Pass
