### PR TITLE
PCHR-2610: Update T&A menu structure

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -597,7 +597,11 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
   public function upgrade_1027() {
     $taDashboard = new CRM_Core_DAO_Navigation();
     $taDashboard->name = 'ta_dashboard';
-    $taDashboard->find(true);
+    $taDashboard->find(TRUE);
+
+    if (!$taDashboard->id) {
+      return TRUE;
+    }
     
     CRM_Core_BAO_Navigation::processDelete($taDashboard->id);
     CRM_Core_BAO_Navigation::resetNavigation();
@@ -611,34 +615,34 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
   public function upgrade_1028() {
     $taNavigation = new CRM_Core_DAO_Navigation();
     $taNavigation->name = 'tasksassignments';
-    $taNavigation->find(true);
+    $taNavigation->find(TRUE);
     
     if (!$taNavigation->id) {
       return TRUE;
     }
 
-    $submenu = array(
-      array(
+    $submenu = [
+      [
         'label' => ts('Tasks'),
         'name' => 'ta_dashboard_tasks',
         'url' => 'civicrm/tasksassignments/dashboard#/tasks',
-      ),
-      array(
+      ],
+      [
         'label' => ts('Documents'),
         'name' => 'ta_dashboard_documents',
         'url' => 'civicrm/tasksassignments/dashboard#/documents',
-      ),
-      array(
+      ],
+      [
         'label' => ts('Calendar'),
         'name' => 'ta_dashboard_calendar',
         'url' => 'civicrm/tasksassignments/dashboard#/calendar',
-      ),
-      array(
+      ],
+      [
         'label' => ts('Key Dates'),
         'name' => 'ta_dashboard_keydates',
         'url' => 'civicrm/tasksassignments/dashboard#/key-dates',
-      )
-    );
+      ]
+    ];
 
     foreach ($submenu as $key => $item) {
       $item['parent_id'] = $taNavigation->id;
@@ -673,7 +677,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
 
     CRM_Core_BAO_Navigation::resetNavigation();
 
-    return true;
+    return TRUE;
   }
 
     public function uninstall() {

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -591,12 +591,96 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     return $this->upgrade_1020();
   }
 
-    public function uninstall()
-    {
-        CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard', 'tasksassignments_administer', 'ta_settings')");
-        CRM_Core_BAO_Navigation::resetNavigation();
+  /**
+   * Remove the old Dashboard submenu item
+   */
+  public function upgrade_1027() {
+    $taDashboard = new CRM_Core_DAO_Navigation();
+    $taDashboard->name = 'ta_dashboard';
+    $taDashboard->find(true);
+    
+    CRM_Core_BAO_Navigation::processDelete($taDashboard->id);
+    CRM_Core_BAO_Navigation::resetNavigation();
 
-        return TRUE;
+    return TRUE;
+  }
+
+  /**
+   * Add new submenu links
+   */
+  public function upgrade_1028() {
+    $taNavigation = new CRM_Core_DAO_Navigation();
+    $taNavigation->name = 'tasksassignments';
+    $taNavigation->find(true);
+    
+    if (!$taNavigation->id) {
+      return TRUE;
+    }
+
+    $submenu = array(
+      array(
+        'label' => ts('Tasks'),
+        'name' => 'ta_dashboard_tasks',
+        'url' => 'civicrm/tasksassignments/dashboard#/tasks',
+      ),
+      array(
+        'label' => ts('Documents'),
+        'name' => 'ta_dashboard_documents',
+        'url' => 'civicrm/tasksassignments/dashboard#/documents',
+      ),
+      array(
+        'label' => ts('Calendar'),
+        'name' => 'ta_dashboard_calendar',
+        'url' => 'civicrm/tasksassignments/dashboard#/calendar',
+      ),
+      array(
+        'label' => ts('Key Dates'),
+        'name' => 'ta_dashboard_keydates',
+        'url' => 'civicrm/tasksassignments/dashboard#/key-dates',
+      )
+    );
+
+    foreach ($submenu as $key => $item) {
+      $item['parent_id'] = $taNavigation->id;
+      $item['weight'] = $key;
+      $item['is_active'] = 1;
+      
+      CRM_Core_BAO_Navigation::add($item);
+    }
+    
+    CRM_Core_BAO_Navigation::resetNavigation();
+    
+    return TRUE;
+  }
+
+  /**
+   * Rename "Tasks and Assignments" menu items to just "Task"
+   */
+  public function upgrade_1029() {
+    $default = [];
+    $paramsDashboard = ['name' => 'tasksassignments'];
+    $paramsAdmin = ['name' => 'tasksassignments_administer'];
+
+    $menuItems = [
+      'dashboard' => CRM_Core_BAO_Navigation::retrieve($paramsDashboard, $default),
+      'admin' => CRM_Core_BAO_Navigation::retrieve($paramsAdmin, $default)
+    ];
+    
+    foreach ($menuItems as $menuItem) {
+      $menuItem->label = 'Tasks';
+      $menuItem->save();
+    }
+
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return true;
+  }
+
+    public function uninstall() {
+      CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard_tasks', 'ta_dashboard_documents', 'ta_dashboard_calendar', 'ta_dashboard_keydates', 'tasksassignments_administer', 'ta_settings')");
+      CRM_Core_BAO_Navigation::resetNavigation();
+
+      return TRUE;
     }
 
     /**


### PR DESCRIPTION
## Overview
This PR updates the menu structure of the T&A extension

## Before
<img width="200" alt="before-menu" src="https://user-images.githubusercontent.com/6400898/31116979-65c37052-a828-11e7-9282-309e3f7fbd08.png">
<img width="200" alt="before-menu-admin" src="https://user-images.githubusercontent.com/6400898/31116993-6f74b002-a828-11e7-8888-c395eea638d4.png">



## After
<img width="200" alt="after-menu" src="https://user-images.githubusercontent.com/6400898/31116921-1ea6f3f6-a828-11e7-9be6-e1fd5da59bc8.png">
<img width="200" alt="after-menu-admin" src="https://user-images.githubusercontent.com/6400898/31116920-1ea47b44-a828-11e7-8ce3-4b66412ea67f.png">