### PR TITLE
PCHR-2611: Rename 'Settings' to 'Tasks Settings'

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -658,7 +658,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
   }
 
   /**
-   * Rename "Tasks and Assignments" menu items to just "Task"
+   * Rename "Tasks and Assignments" menu items to just "Tasks"
    */
   public function upgrade_1029() {
     $default = [];
@@ -675,6 +675,22 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
       $menuItem->save();
     }
 
+    CRM_Core_BAO_Navigation::resetNavigation();
+
+    return TRUE;
+  }
+
+  /**
+   * Rename "Settings" menu item to "Tasks Settings"
+   */
+  public function upgrade_1030() {
+    $default = [];
+    $params = ['name' => 'ta_settings'];
+    
+    $menuItem = CRM_Core_BAO_Navigation::retrieve($params, $default);
+    $menuItem->label = 'Tasks Settings';
+    $menuItem->save();
+    
     CRM_Core_BAO_Navigation::resetNavigation();
 
     return TRUE;

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -258,6 +258,98 @@ function tasksassignments_civicrm_permission(&$permissions) {
 }
 
 /**
+ * Implements hook_civicrm_navigationMenu().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/
+ */
+function tasksassignments_civicrm_navigationMenu(&$params) {
+  _tasksassignments_moveCiviCaseAdminSubMenuItemsUnderTaskAdminSubMenu($params);
+}
+
+/**
+ * Moves some of the items of the "Administer > Civi Case" sub menu under the "Administer > Tasks" sub menu
+ *
+ * @param array $params
+ */
+function _tasksassignments_moveCiviCaseAdminSubMenuItemsUnderTaskAdminSubMenu(&$params) {
+  $administerMenuItems = &_tasksassignments_getAdministerMenuItems($params);
+  $menuItemsToClone = _tasksassignments_filterMenuItemsOfAdministerSubMenu($administerMenuItems, 'CiviCase', ['Case Types', 'Case Statuses']);
+
+  _tasksassignments_cloneMenuItemsInAdministerSubMenu($administerMenuItems, $menuItemsToClone, 'tasksassignments_administer', [
+    'Case Types' => 'Workflows',
+    'Case Statuses' => 'Workflows Status'
+  ]);
+  
+  _tasksassignments_deleteAdministerSubMenu($administerMenuItems, 'CiviCase');
+}
+
+/**
+ * Deletes a sub menu of the given name from the Administer main menu
+ *
+ * @param array $administerMenuItems 
+ * @param string $subMenuName
+ */
+function _tasksassignments_deleteAdministerSubMenu(&$administerMenuItems, $subMenuName) {
+  $subMenuID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $subMenuName, 'id', 'name');
+
+  unset($administerMenuItems[$subMenuID]);
+}
+
+/**
+ * Clones the given set of menu items into the sub menu of the given name.
+ * It also changes the label of the menu items by using a given mapping
+ *
+ * @param array $administerMenuItems
+ * @param array $menuItems
+ * @param array $subMenuName
+ * @param array $labelsMapping
+ */
+function _tasksassignments_cloneMenuItemsInAdministerSubMenu(&$administerMenuItems, $menuItems, $subMenuName, $labelsMapping) {
+  $subMenuTargetID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $subMenuName, 'id', 'name');
+
+  foreach ($menuItems as $item) {
+    $itemID = $item['attributes']['navID'];
+    $item['attributes']['parentID'] = $subMenuTargetID; 
+
+    if ($labelsMapping[$item['attributes']['name']]) {
+      $item['attributes']['label'] = $labelsMapping[$item['attributes']['name']];
+    }
+
+    $administerMenuItems[$subMenuTargetID]['child'][$itemID] = $item;
+  }
+}
+
+/**
+ * Filters the items (by name) of the Administer's sub menu of the given name
+ *
+ * @param array $administerMenuItems
+ * @param string $subMenuName
+ * @param array $namesFilter
+ * @return array
+ */
+function _tasksassignments_filterMenuItemsOfAdministerSubMenu($administerMenuItems, $subMenuName, $namesFilter) {
+  $subMenuID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $subMenuName, 'id', 'name');
+
+  return array_filter($administerMenuItems[$subMenuID]['child'], function ($child) use ($namesFilter) {
+    $childName = $child['attributes']['name'];
+
+    return in_array($childName, $namesFilter);
+  });
+}
+
+/**
+ * Gets the items of the Administer main menu
+ *
+ * @param array $params
+ * @return array
+ */
+function &_tasksassignments_getAdministerMenuItems(&$params) {
+  $administerID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
+
+  return $params[$administerID]['child'];
+}
+
+/**
  * Sets the is_state flag of its own menu items
  *
  * @param boolean $activate

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -275,7 +275,7 @@ function _tasksassignments_moveCiviCaseAdminSubMenuItemsUnderTaskAdminSubMenu(&$
   $administerMenuItems = &_tasksassignments_getAdministerMenuItems($params);
   $menuItemsToClone = _tasksassignments_filterMenuItemsOfAdministerSubMenu($administerMenuItems, 'CiviCase', ['Case Types', 'Case Statuses']);
 
-  _tasksassignments_cloneMenuItemsInAdministerSubMenu($administerMenuItems, $menuItemsToClone, 'tasksassignments_administer', [
+  _tasksassignments_cloneMenuItemsInAdministerSubMenuAndChangeLabels($administerMenuItems, $menuItemsToClone, 'tasksassignments_administer', [
     'Case Types' => 'Workflows',
     'Case Statuses' => 'Workflows Status'
   ]);
@@ -284,15 +284,35 @@ function _tasksassignments_moveCiviCaseAdminSubMenuItemsUnderTaskAdminSubMenu(&$
 }
 
 /**
- * Deletes a sub menu of the given name from the Administer main menu
+ * Gets the items of the Administer main menu
  *
- * @param array $administerMenuItems 
- * @param string $subMenuName
+ * @param array $params
+ *
+ * @return array
  */
-function _tasksassignments_deleteAdministerSubMenu(&$administerMenuItems, $subMenuName) {
+function &_tasksassignments_getAdministerMenuItems(&$params) {
+  $administerID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
+
+  return $params[$administerID]['child'];
+}
+
+/**
+ * Filters the items (by name) of the Administer's sub menu of the given name
+ *
+ * @param array $administerMenuItems
+ * @param string $subMenuName
+ * @param array $namesFilter
+ *
+ * @return array
+ */
+function _tasksassignments_filterMenuItemsOfAdministerSubMenu($administerMenuItems, $subMenuName, $namesFilter) {
   $subMenuID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $subMenuName, 'id', 'name');
 
-  unset($administerMenuItems[$subMenuID]);
+  return array_filter($administerMenuItems[$subMenuID]['child'], function ($child) use ($namesFilter) {
+    $childName = $child['attributes']['name'];
+
+    return in_array($childName, $namesFilter);
+  });
 }
 
 /**
@@ -304,7 +324,7 @@ function _tasksassignments_deleteAdministerSubMenu(&$administerMenuItems, $subMe
  * @param array $subMenuName
  * @param array $labelsMapping
  */
-function _tasksassignments_cloneMenuItemsInAdministerSubMenu(&$administerMenuItems, $menuItems, $subMenuName, $labelsMapping) {
+function _tasksassignments_cloneMenuItemsInAdministerSubMenuAndChangeLabels(&$administerMenuItems, $menuItems, $subMenuName, $labelsMapping) {
   $subMenuTargetID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $subMenuName, 'id', 'name');
 
   foreach ($menuItems as $item) {
@@ -320,33 +340,15 @@ function _tasksassignments_cloneMenuItemsInAdministerSubMenu(&$administerMenuIte
 }
 
 /**
- * Filters the items (by name) of the Administer's sub menu of the given name
+ * Deletes a sub menu of the given name from the Administer main menu
  *
- * @param array $administerMenuItems
+ * @param array $administerMenuItems 
  * @param string $subMenuName
- * @param array $namesFilter
- * @return array
  */
-function _tasksassignments_filterMenuItemsOfAdministerSubMenu($administerMenuItems, $subMenuName, $namesFilter) {
+function _tasksassignments_deleteAdministerSubMenu(&$administerMenuItems, $subMenuName) {
   $subMenuID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', $subMenuName, 'id', 'name');
 
-  return array_filter($administerMenuItems[$subMenuID]['child'], function ($child) use ($namesFilter) {
-    $childName = $child['attributes']['name'];
-
-    return in_array($childName, $namesFilter);
-  });
-}
-
-/**
- * Gets the items of the Administer main menu
- *
- * @param array $params
- * @return array
- */
-function &_tasksassignments_getAdministerMenuItems(&$params) {
-  $administerID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_Navigation', 'Administer', 'id', 'name');
-
-  return $params[$administerID]['child'];
+  unset($administerMenuItems[$subMenuID]);
 }
 
 /**

--- a/uk.co.compucorp.civicrm.tasksassignments/views/settings.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/settings.html
@@ -1,7 +1,7 @@
 <div class="{{prefix}}page-settings" ct-spinner>
     <div class="panel panel-secondary">
         <div class="panel-heading">
-            <h3 class="panel-title">Settings</h3>
+            <h3 class="panel-title">Tasks Settings</h3>
         </div>
         <div class="panel-body">
             <form novalidate name="settingsForm" class="form-horizontal form-settings" role="form" ng-submit="confirm()">

--- a/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/xml/Menu/tasksassignments.xml
@@ -31,7 +31,7 @@
   </item>
   <item>
     <path>civicrm/tasksassignments/settings</path>
-    <title>Settings</title>
+    <title>Tasks Settings</title>
     <page_callback>CRM_Tasksassignments_Page_Settings</page_callback>
     <access_arguments>administer CiviCRM</access_arguments>
   </item>


### PR DESCRIPTION
## Overview
1. The PR amends the structure of the "Configure" menu, moving the content of "Configure > People Management" submenu under "Configure > Tasks"
2. Also, in https://github.com/compucorp/civihr-tasks-assignments/pull/260 i forgot to update the "Configure > Settings" label, this PR takes care of that

## Before
1.  <img width="350" alt="before" src="https://user-images.githubusercontent.com/6400898/31188898-d3033634-a936-11e7-9ad5-f00f4a9a5eaf.png">

2. The label was "Configure > Settings"

## After
1.  <img width="350" alt="after" src="https://user-images.githubusercontent.com/6400898/31188908-d8abe86a-a936-11e7-96f2-6c85a94502ab.png">

2. The label is "Configure > Tasks Settings"
