### PR TITLE
PCHR-2753: Tasks filter by date doesn't work on 1.6 and 1.7

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -42,7 +42,7 @@
                 My Docs
               <span>
                 ({{
-                  ((list.filterByDateField(list.filterParams.due)) |
+                  (list.filterByDateField(list.filterParams.due) |
                   filterByStatus:list.filterParams.documentStatus |
                   filterByOwnership:'assigned').length
                 }})
@@ -56,7 +56,7 @@
                 Delegated Docs
               <span>
                 ({{
-                  ((list.filterByDateField(list.filterParams.due)) |
+                  (list.filterByDateField(list.filterParams.due) |
                   filterByStatus:list.filterParams.documentStatus |
                   filterByOwnership:'delegated').length
                 }})
@@ -70,7 +70,7 @@
                 All
               <span>
                 ({{
-                  ((list.filterByDateField(list.filterParams.due)) |
+                  (list.filterByDateField(list.filterParams.due) |
                   filterByStatus:list.filterParams.documentStatus).length
                 }})
               </span>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/documents.html
@@ -70,8 +70,7 @@
                 All
               <span>
                 ({{
-                  (list.list |
-                  filterByDateField:list.filterParams.due:list.filterParams.dateRange |
+                  ((list.filterByDateField(list.filterParams.due)) |
                   filterByStatus:list.filterParams.documentStatus).length
                 }})
               </span>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -69,7 +69,6 @@
                           </a>
                         </span>
                       </div>
-
                     </div>
                   </div>
                 </div>
@@ -92,8 +91,15 @@
           </div>
         </div>
         <ul class="{{prefix}}list-task">
-          <li ng-repeat="task in listFiltered = (listUnlimited = (listOngoing = (list.list | filterByStatus:cache.taskStatusResolve:false) | filterByDateField:list.filterParams.due:list.filterParams.dateRange | filterByOwnership:list.filterParams.ownership | filterByAssignmentType:list.filterParams.assignmentType | filterByContactId:list.filterParams.contactId | orderBy: 'activity_date_time') | limitTo: listLimit)"
-            ng-controller="TaskCtrl" ng-class="{ '{{prefix}}task-completed': task.completed, '{{prefix}}task-due': task.due }" ng-include src="'task.html'" ct-spinner ct-spinner-id="task{{task.id}}">
+          <li ng-repeat="task in listFiltered = (listUnlimited = (listOngoing = (list.filterByDateField(list.filterParams.due)
+            | filterByStatus:cache.taskStatusResolve:false)
+            | filterByOwnership:list.filterParams.ownership
+            | filterByAssignmentType:list.filterParams.assignmentType
+            | filterByContactId:list.filterParams.contactId
+            | orderBy: 'activity_date_time')
+            | limitTo: listLimit)"
+            ng-controller="TaskCtrl" ng-class="{ '{{prefix}}task-completed': task.completed, '{{prefix}}task-due': task.due }"
+            ng-include src="'task.html'" ct-spinner ct-spinner-id="task{{task.id}}">
           </li>
         </ul>
       </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -23,19 +23,19 @@
                   <a ui-sref="tasks.my" class="btn btn-gray active panel-filter__filter" ng-model="list.filterParams.ownership" uib-btn-radio="'assigned'">
                     My Tasks
                     <span>
-                      ({{(list.list | filterByDateField:list.filterParams.due:list.filterParams.dateRange | filterByStatus:cache.taskStatusResolve:false | filterByOwnership:'assigned').length}})
+                      ({{(list.filterByDateField(list.filterParams.due) | filterByStatus:cache.taskStatusResolve:false | filterByOwnership:'assigned').length}})
                     </span>
                   </a>
                   <a ui-sref="tasks.delegated" class="btn btn-gray panel-filter__filter" ng-model="list.filterParams.ownership" uib-btn-radio="'delegated'">
                     Delegated Tasks
                     <span>
-                      ({{(list.list | filterByDateField:list.filterParams.due:list.filterParams.dateRange | filterByStatus:cache.taskStatusResolve:false | filterByOwnership:'delegated').length}})
+                      ({{(list.filterByDateField(list.filterParams.due) | filterByStatus:cache.taskStatusResolve:false | filterByOwnership:'delegated').length}})
                     </span>
                   </a>
                   <a ui-sref="tasks.all" class="btn btn-gray panel-filter__filter" ng-model="list.filterParams.ownership" uib-btn-radio="null">
                     All
                     <span>
-                      ({{(list.list | filterByDateField:list.filterParams.due:list.filterParams.dateRange | filterByStatus:cache.taskStatusResolve:false).length}})
+                      ({{(list.filterByDateField(list.filterParams.due) | filterByStatus:cache.taskStatusResolve:false).length}})
                     </span>
                   </a>
                 </div>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -91,13 +91,16 @@
           </div>
         </div>
         <ul class="{{prefix}}list-task">
-          <li ng-repeat="task in listFiltered = (listUnlimited = (listOngoing = (list.filterByDateField(list.filterParams.due)
-            | filterByStatus:cache.taskStatusResolve:false)
-            | filterByOwnership:list.filterParams.ownership
-            | filterByAssignmentType:list.filterParams.assignmentType
-            | filterByContactId:list.filterParams.contactId
-            | orderBy: 'activity_date_time')
-            | limitTo: listLimit)"
+          <li ng-repeat="task in listFiltered =
+            (listUnlimited =
+              (listOngoing =
+                (list.filterByDateField(list.filterParams.due)
+                | filterByStatus:cache.taskStatusResolve:false)
+                | filterByOwnership:list.filterParams.ownership
+                | filterByAssignmentType:list.filterParams.assignmentType
+                | filterByContactId:list.filterParams.contactId
+                | orderBy: 'activity_date_time'
+              ) | limitTo: listLimit)"
             ng-controller="TaskCtrl" ng-class="{ '{{prefix}}task-completed': task.completed, '{{prefix}}task-due': task.due }"
             ng-include src="'task.html'" ct-spinner ct-spinner-id="task{{task.id}}">
           </li>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/directives/sidebar-filters.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/directives/sidebar-filters.html
@@ -31,7 +31,6 @@
           is-open="list.dpOpened.filterDates.from"
           uib-datepicker-popup="dd/MM/yyyy"
           datepicker-options="list.datepickerOptions.from"
-          ng-click="list.dpOpened.filterDates.from = !list.dpOpened.filterDates.from"
           ng-model="list.filterParamsHolder.dateRange.from"
           id="{{prefix}}filter-date-from" class="form-control" name="filterDateFrom">
       </div>
@@ -45,7 +44,6 @@
           is-open="list.dpOpened.filterDates.until"
           uib-datepicker-popup="dd/MM/yyyy"
           datepicker-options="list.datepickerOptions.until"
-          ng-click="list.dpOpened.filterDates.until = !list.dpOpened.filterDates.until"
           ng-model="list.filterParamsHolder.dateRange.until"
           id="{{prefix}}filter-date-until" class="form-control" name="filterDateUntil">
       </div>


### PR DESCRIPTION
## Overview
After adding fix in PR #245 and in course of adopting angular js style guide, there left few regression issues causing the filters in tasks broken:
issues:
1. https://github.com/compucorp/civihr-tasks-assignments/pull/245/files#diff-9ddc2c346e6840e0dfe2f4c8d2217fb3R96
2. https://github.com/compucorp/civihr-tasks-assignments/pull/245/files#diff-d034a1547714f392d984ef97994dd244R34
3. https://github.com/compucorp/civihr-tasks-assignments/pull/245/files#diff-d034a1547714f392d984ef97994dd244R48

This PR fixes those introduced/unnoticed issues both in `/tasks` and `/documents`

## Before
1. The task filters were broken.
![datetasks](https://user-images.githubusercontent.com/6307362/31445736-6622c998-aebe-11e7-9256-690e891953ab.gif)

2. Filtering the tasks when clicking the tabs in `/tasks` not working with correct counter value.
![tasksandfilters](https://user-images.githubusercontent.com/6307362/31486390-070445ec-af57-11e7-81c8-d2f1f8250e6d.gif)

## After
1. The tasks filters work properly.
![2572-after-min](https://user-images.githubusercontent.com/6307362/31445968-17fdff8e-aebf-11e7-93ce-a2ea377a0901.gif)

2. Filtering the tasks when clicking the tab in `/tasks` not works with correct counter value.
![2753-ffix-iloveimg-compressed](https://user-images.githubusercontent.com/6307362/31488542-a7cfab3c-af5d-11e7-9d5e-efd8da5ce1eb.gif)

3. Filtering the Documents when clicking the tab in `/documents` works with correct counter value.
![2753-fix-plus-min](https://user-images.githubusercontent.com/6307362/31488295-ea3831d4-af5c-11e7-9557-b026e6c7ced5.gif)

## Technical Details
1. Use defined function `filterByDateField()` for filter tasks by date range in task list in file `/views/dashboard/tasks.html`
```html
<li ng-repeat="task in listFiltered = (listUnlimited = (listOngoing = (list.filterByDateField(list.filterParams.due) ...) | limitTo: listLimit)"
```
2. Remove unnecessary code in sidebar filters, form date picker fields. Which were breaking filters in Task list. These changes were already removed in [commit](https://github.com/compucorp/civihr-tasks-assignments/commit/2dd8969072bc78d85d0448815aab595679a885cf#diff-d034a1547714f392d984ef97994dd244) in file `/views/directives/sidebar-filters.html`.

```html
..
ng-click="list.dpOpened.filterDates.from = !list.dpOpened.filterDates.from"
..
ng-click="list.dpOpened.filterDates.until = !list.dpOpened.filterDates.until"
..
```
3. Use the ``filterByDateField()`` function to filter tasks by date range in tabbed task filters in `/tasks` in T&A Dashboard (file: /views/dashboard/tasks.html)
```html
<div class="col-xs-12 col-sm-6 text-center">
    ...
    My Tasks
    <span>
        ({{(list.filterByDateField(list.filterParams.due) | filterByStatus:cache.taskStatusResolve:false | filterByOwnership:'assigned').length}})
    </span>
    ...
    Delegated Tasks
    <span>
       ({{(list.filterByDateField(list.filterParams.due) | filterByStatus:cache.taskStatusResolve:false | filterByOwnership:'delegated').length}})
    </span>
    ...
    All
    <span>
        ({{(list.filterByDateField(list.filterParams.due) | filterByStatus:cache.taskStatusResolve:false).length}})
   ...
</div>
```
4. Use function `filterByDateField()` in "views/dashboard/documents.html"
```html
<a ... 
    All
    <span>
        ({{
           ((list.filterByDateField(list.filterParams.due)) | filterByStatus:list.filterParams.documentStatus).length
         }})
     </span>
</a>
```
## For QA:
1. Verify that the tasks can be filtered in `/tasks` in T&A:
- Over Due
- Due Today
- Due This week

2. Verify that the filtering tasks works with correct counter by clicking following  in `/tasks`.
- My Tasks
- Delegated Tasks
- All

3. Verify that the filtering documents works with correct counter by clicking following in `/dcuments`: 
- My Docs
- Delegated Docs
- All

4. Verify the tasks can be filtered using custom date ranges 
5. Verify that filtering documents in `/documents` path in T&A still works 

## Comments
- Verified that the task filters work as expected.
- Also verified the document filters work as expected.

## Tests
✅ Jasmine Tests - passed
⏹ JS distributive files - not needed
⏹ Backstop Tests - n/a
⏹ PHP Unit Tests - not needed to be run
⏹ CSS distributive files - not needed
