### PR TITLE
PCHR-2999: Toggle collapsing of specific task

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/js/test/controllers/modal/modal-document.spec.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/test/controllers/modal/modal-document.spec.js
@@ -45,6 +45,7 @@ define([
       AssignmentService = _AssignmentService_;
       AppSettingsService = _AppSettingsService_;
       fileService = _fileService_;
+      window.alert = function () {}; // prevent alert from being logged in console
 
       $rootScope.cache.documentStatus.obj = {
         1: 'awaiting upload',

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/tasks.html
@@ -195,14 +195,14 @@
   </div>
   <div class="row">
     <div class="col-xs-12">
-      <a href ng-click="list.isCollapsed = !list.isCollapsed" class="btn btn-collapse">
-        <span class="fa" ng-class="{fa: true, 'fa-chevron-down': !list.isCollapsed, 'fa-chevron-right': list.isCollapsed }" aria-hidden="true">
+      <a href ng-click="isCollapsed = !isCollapsed" class="btn btn-collapse">
+        <span class="fa" ng-class="{fa: true, 'fa-chevron-down': !isCollapsed, 'fa-chevron-right': isCollapsed }" aria-hidden="true">
         </span>
         Show More
       </a>
     </div>
   </div>
-  <article class="row" uib-collapse="list.isCollapsed">
+  <article class="row" uib-collapse="isCollapsed">
     <div class="col-xs-12">
       <div class="{{prefix}}task-more">
         <div editable-ta="task.details" onbeforesave="list.updateTask(task, { details: ta.$data });">


### PR DESCRIPTION
## Overview
This PR fixes the issue being all tasks and filter section gets expanded and collapsed on clicking "show more" label in each task in T&A tasks dashboard.

## Before
- Expands and collapses all tasks:
![expandfilters](https://user-images.githubusercontent.com/6307362/33482882-446a1dec-d6c3-11e7-96f1-00c86ce2f52a.gif)

## After
![2999-after](https://user-images.githubusercontent.com/6307362/33482997-bc3f4d24-d6c3-11e7-854f-33b4cc2fba47.gif)

## Technical Details
1. Use "isCollapsed" property from Task controller. Currently its using of Task List controller.
```html
<div class="row">
   <div class="col-xs-12">
      <a href ng-click="isCollapsed = !isCollapsed" class="btn btn-collapse">
        <span class="fa" ng-class="{fa: true, 'fa-chevron-down': !isCollapsed, 'fa-chevron-right': isCollapsed }" aria-hidden="true">
        </span>
        Show More
      </a>
   </div>
</div>
<article class="row" uib-collapse="isCollapsed">
      ....
</article>
```

## Tests
- Not required
