### PR TITLE
PCHR-2919: Fix responsiveness

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Documents.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Documents.tpl
@@ -2,7 +2,7 @@
 {assign var="prefix" value="ct-" }
 
 <div id="{$module}" ng-controller="MainController" ct-spinner ct-spinner-show>
-    <div class="container fade-in" ui-view>
+    <div class="container-fluid fade-in" ui-view>
     </div>
 </div>
 {literal}

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Tasks.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Page/Tasks.tpl
@@ -2,7 +2,7 @@
 {assign var="prefix" value="ct-" }
 
 <div id="{$module}" ng-controller="MainController" ct-spinner ct-spinner-show>
-    <div class="container fade-in" ui-view>
+    <div class="container-fluid fade-in" ui-view>
     </div>
 </div>
 {literal}


### PR DESCRIPTION
## Overview
As part of https://github.com/civicrm/civihr/pull/2374, all the tabs Contact Profile page having `container` class, has been changed to `container-fluid`. This PR updates the same for Tasks and Documents.

## Technical Details
Replaced `container` with `container-fluid`, and the css styles are applied from https://github.com/compucorp/org.civicrm.shoreditch/pull/75. No visual change has happened.
  