### PR TITLE
PCHR-3058: Fix tasks list issues

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -40,7 +40,7 @@
       Loading resolved tasks...
       <div class="{{prefix}}spinner-cover spinner"></div>
     </div>
-    <div class="alert alert-danger" ng-show="list.listResolvedLoaded && !list.listResolved.length">No results found.</div>
+    <div class="alert alert-danger" ng-show="list.listResolvedLoaded && !listResolved.length">No results found.</div>
     <ul class="{{prefix}}list-task">
       <li ng-repeat="task in listResolved = (listFiltered | filterByStatus:cache.taskStatusResolve:true)" ng-controller="TaskController" ng-class="'{{prefix}}task-resolved'" ng-include src="'task.html'" ct-spinner>
       </li>

--- a/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/contact/tasks.html
@@ -94,14 +94,14 @@
   </div>
   <div class="row">
     <div class="col-xs-12">
-      <a href ng-click="list.isCollapsed = !list.isCollapsed" class="btn btn-collapse">
+      <a href ng-click="isCollapsed = !isCollapsed" class="btn btn-collapse">
         <span class="fa"
-          ng-class="{fa: true, 'fa-chevron-down': !list.isCollapsed, 'fa-chevron-right': list.isCollapsed }"
+          ng-class="{fa: true, 'fa-chevron-down': !isCollapsed, 'fa-chevron-right': isCollapsed }"
           aria-hidden="true">
         </span>
         Show More
       </a>
-      <article class="row" uib-collapse="list.isCollapsed">
+      <article class="row" uib-collapse="isCollapsed">
         <div class="col-xs-12">
           <div class="{{prefix}}task-more">
             <div editable-ta="task.details" onbeforesave="list.updateTask(task, { details: ta.$data });">

--- a/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
+++ b/uk.co.compucorp.civicrm.tasksassignments/views/dashboard/calendar.taskList.html
@@ -72,15 +72,15 @@
   </div>
   <div class="row">
     <div class="col-xs-12">
-      <a href ng-click="list.isCollapsed = !list.isCollapsed" class="btn btn-collapse">
+      <a href ng-click="isCollapsed = !isCollapsed" class="btn btn-collapse">
         <span
           class="fa"
-          ng-class="{fa: true, 'fa-chevron-down': !list.isCollapsed, 'fa-chevron-right': list.isCollapsed }"
+          ng-class="{fa: true, 'fa-chevron-down': !isCollapsed, 'fa-chevron-right': isCollapsed }"
           aria-hidden="true">
         </span>
         Show More
       </a>
-      <article class="row" uib-collapse="list.isCollapsed">
+      <article class="row" uib-collapse="isCollapsed">
         <div class="col-xs-12">
           <div class="{{prefix}}task-more">
             <div editable-ta="task.details" onbeforesave="list.updateTask(task, { details: ta.$data });">


### PR DESCRIPTION
## Overview
This PR fixes the following issues with Tasks in the contact section and calendar:

* When clicking "Show More" all tasks would expand or collapse at the same time.
* When Clicking on "Resolved" a "No results found." would always be displayed regardless of the tasks displayed.

## Before
![anim](https://user-images.githubusercontent.com/1642119/34882120-eb925c54-f78b-11e7-863b-d939930fd576.gif)
* Note: the resolved panel stops working after opening it for the first time.


## After
![anim](https://user-images.githubusercontent.com/1642119/34881949-5f409d24-f78b-11e7-8ea7-eebd23014399.gif)

## Technical Details

To fix the "Show More" issue the `list.isCollapsed` was changed to a local variable per task: `isCollapsed`. This avoids collapsing all tasks at the same time.

To fix the Resolved tasks the proper variable name was `listResolved` instead of `list.listResolved`:

```html
<div class="alert alert-danger" ng-show="list.listResolvedLoaded && !listResolved.length">No results found.</div>
```

## Comments
BackstopJS tests were run successfully

---

- [x] Tests Pass
