### PR TITLE
PCHR-3201: Fix Tests

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Task.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Task.php
@@ -5,12 +5,9 @@
  */
 class CRM_Tasksassignments_Test_Fabricator_Task {
 
-  private static $defaultParams = [
-    'activity_name' => 'Test Task',
-  ];
-
   /**
    * Fabricates a task merging given parameters with default minimum params.
+   * Requires activity_type_id and source_contact_id
    *
    * @param array $params
    *   List of parameters to use to create the Assignment
@@ -18,7 +15,6 @@ class CRM_Tasksassignments_Test_Fabricator_Task {
    * @return array
    */
   public static function fabricate($params = []) {
-    $params = array_merge($params, self::$defaultParams);
     $result = civicrm_api3('Task', 'create', $params);
 
     return array_shift($result['values']);

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use CRM_Tasksassignments_Test_Fabricator_OptionValue as OptionValueFabricator;
+use CRM_Tasksassignments_Test_BaseHeadlessTest as BaseHeadlessTest;
 
 /**
- * Class Api_TaskTest
+ * @group headless
  */
-class api_v3_TaskTest extends CiviUnitTestCase {
+class api_v3_TaskTest extends BaseHeadlessTest {
 
   /**
    * @var int


### PR DESCRIPTION
## Overview

The CiviHR pingback tests use the `CRM_Tasksassignments_Test_Fabricator_Task`, but after the changes in #297 it no longer provides a default task type is needs to be updated.

## Before

The `CRM_Tasksassignments_Test_Fabricator_Task` provided a default task type and would not allow overriding.

## After

The task type (`activity_type_id`) is required in the `$params`

---

- [x] Tests Pass
