### PR TITLE
PCHR-3171: Fixing Task Get Filter

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Activity/Service/ActivityService.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Activity/Service/ActivityService.php
@@ -2,6 +2,10 @@
 
 class CRM_Activity_Service_ActivityService {
 
+  const RECORD_TYPE_ASSIGNEE = 1;
+  const RECORD_TYPE_CREATOR = 2;
+  const RECORD_TYPE_TARGET = 3;
+
   /**
    * Returns the activity types for a certain component.
    * Default limit is 0 (unlimited)

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
@@ -2,6 +2,8 @@
 
 use CRM_Tasksassignments_Test_Fabricator_OptionValue as OptionValueFabricator;
 use CRM_Tasksassignments_Test_BaseHeadlessTest as BaseHeadlessTest;
+use CRM_Tasksassignments_Test_Fabricator_Task as TaskFabricator;
+use CRM_Tasksassignments_Test_Fabricator_Contact as ContactFabricator;
 
 /**
  * @group headless
@@ -81,6 +83,24 @@ class api_v3_TaskTest extends BaseHeadlessTest {
       'source_contact_id' => 1,
       'assignee_contact_id' => 2,
     ]);
+  }
+
+  public function testFetchingBySourceWillReturnExpectedTasks() {
+    $sourceContact = ContactFabricator::fabricate();
+    $contactId = $sourceContact['id'];
+    $params = [
+      'activity_type_id' => $this->_taskTypeId,
+      'source_contact_id' => $contactId,
+      'target_contact_id' => $contactId,
+    ];
+    $task = TaskFabricator::fabricate($params);
+
+    $params = ['source_contact_id' => $contactId];
+    $results = civicrm_api3('Task', 'get', $params);
+
+    $this->assertEquals(1, $results['count']);
+    $returnedTask = array_shift($results['values']);
+    $this->assertEquals($task['id'], $returnedTask['id']);
   }
 
 }


### PR DESCRIPTION
## Overview

In [this commit](https://github.com/compucorp/civihr-tasks-assignments/commit/6ce23f327ab4986714aa40dc2d22ea0ee9f43e0a) the existing code was refactored to reduce repetition. However the `record_type_id` was not preserved, which meant that all requests that used the `source_contact_id` would instead search for tasks with that assignee ID.

## Before

Requests to Task.get filtering by `source_contact_id` would instead return tasks with assignees with the given `source_contact_id`.

## After

Filtering by `source_contact_id` will return Tasks with that source contact ID. 

---

- [x] Tests Pass