### PR TITLE
PCHR-3050: Replace Drupal user IDs with CiviCRM contact IDs

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -395,8 +395,20 @@ class CRM_Tasksassignments_Reminder {
 
     $result = db_query($query, $queryParams);
     $uids = $result->fetchCol();
+    $contactIDs = [];
 
-    return $uids;
+    if (empty($uids)) {
+      return $contactIDs;
+    }
+
+    $params = ['uf_id' => ['IN' => $uids]];
+    $ufMatches = civicrm_api3('UFMatch', 'get', $params)['values'];
+
+    if (count($ufMatches) < 1) {
+      return $ufMatches;
+    }
+
+    return array_column($ufMatches, 'contact_id');
   }
 
   /**


### PR DESCRIPTION
## Overview

With no tasks or document reminders to be set the changes in #169 meant that admins were always added to the list of recipients. However the [method](https://github.com/compucorp/civihr-tasks-assignments/pull/169/files#diff-11a08f8d66984202e4167d6d1176103cR361) to get the Admin contact IDs actually returns Drupal user IDs.

By changing this to return admin contact IDs the admins will receive an email with the key dates, regardless if there are no task / document reminders.

## Before

`_getAdminContactIds` returned a list of Drupal user IDs with `civihr_admin` or `administrator` roles. In cases where there are no other task or document reminders the key dates alone will not be sent since this method will return a list of Druapl user IDs which will fail the check for [canSeeKeyDates](https://github.com/compucorp/civihr-tasks-assignments/blob/d8de3df5d3a78935d8fd4571d08029f9c63bc562/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php#L579) later.

## After

`_getAdminContactIds` returns a list of CiviCRM contact IDs with `civihr_admin` or `administrator` roles. In cases where there are no other task or document reminders the key dates will still be sent to the contacts with `civihr_admin` or `administrator` roles.

---

- [x] Tests Pass
