### PR TITLE
PCHR-3105: Run T&A tests with Jenkins

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,3 @@ _If the PR introduces noteworthy technical changes, please describe them here. P
 
 ## Comments
 _Anything else you would like the reviewer to note_
-
----
-
-- [ ] Tests Pass

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,290 @@
+#!groovy
+
+pipeline {
+  agent any
+
+  parameters {
+    string(name: 'BUILDNAME', defaultValue: "ta-dev_$BRANCH_NAME", description: 'T&A test site name')
+    booleanParam(name: 'DESTROY_SITE', defaultValue: true, description: 'Destroy built site after build finish')
+  }
+
+  environment {
+    WEBROOT = "/opt/buildkit/build/${params.BUILDNAME}"
+    CIVICRM_EXT_ROOT = "$WEBROOT/sites/all/modules/civicrm/tools/extensions"
+    EXTENSION_ROOT = "$CIVICRM_EXT_ROOT/civihr_tasks/uk.co.compucorp.civicrm.tasksassignments"
+    WEBURL = "http://jenkins.compucorp.co.uk:8901"
+    ADMIN_PASS = credentials('TEST_SITE_ADMIN_PASS')
+    TEST_REPORTS = "$WORKSPACE/test-reports"
+  }
+
+  stages {
+    stage('Pre-tasks execution') {
+      steps {
+        sendBuildStartdNotification()
+
+        // Print all Environment variables
+        sh 'printenv | sort'
+
+        // Update buildkit
+        sh "cd /opt/buildkit && git pull"
+
+        // Destroy existing site
+        sh "civibuild destroy ${params.BUILDNAME} || true"
+
+        // Test build tools
+        sh 'amp test'
+
+        // Recreate the test reports folder to make sure it
+        // will be empty when the tests run and there is no
+        // risk of having results from previous tests there
+        sh 'rm -rf $TEST_REPORTS'
+        sh 'mkdir $TEST_REPORTS'
+      }
+    }
+
+    stage('Build site') {
+      steps {
+        script {
+          // Build site with CV Buildkit
+          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 4.7.27 --url $WEBURL --admin-pass $ADMIN_PASS"
+
+          // Get target and PR branches name
+          def prBranch = env.CHANGE_BRANCH
+          def envBranch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
+          if (prBranch != null && prBranch.startsWith("hotfix-")) {
+            envBranch = 'master'
+          }
+
+          cloneRepositories(envBranch)
+
+          if (prBranch) {
+            checkoutPrBranchInRepositories(prBranch)
+            mergeEnvBranchInAllRepositories(envBranch)
+          }
+
+          // The JS tests use the cv tool to find the path  of an extension.
+          // For it to work, the extensions have to be installed on the site
+          installExtensionAndDependencies()
+        }
+      }
+    }
+
+    stage('Run tests') {
+      parallel {
+        stage('Test PHP') {
+          steps {
+            sh """
+              cd $EXTENSION_ROOT
+              phpunit4 --log-junit $TEST_REPORTS/phpunit.xml
+            """
+          }
+          post {
+            always {
+              step([
+                $class: 'XUnitBuilder',
+                thresholds: [
+                  [
+                    $class: 'FailedThreshold',
+                    failureNewThreshold: '1',
+                    failureThreshold: '1',
+                    unstableNewThreshold: '1',
+                    unstableThreshold: '1'
+                  ]
+                ],
+                tools: [
+                  [
+                    $class: 'JUnitType',
+                    pattern: 'test-reports/phpunit.xml'
+                  ]
+                ]
+              ])
+            }
+          }
+        }
+
+        stage('Test JS') {
+          steps {
+            sh """
+              cd $EXTENSION_ROOT
+              yarn || true
+              gulp test --reporters junit,progress || true
+              ls -l
+              mv test-reports/karma.xml $TEST_REPORTS/
+            """
+          }
+          post {
+            always {
+              step([
+                $class: 'XUnitBuilder',
+                thresholds: [
+                  [
+                    $class: 'FailedThreshold',
+                    failureNewThreshold: '1',
+                    failureThreshold: '1',
+                    unstableNewThreshold: '1',
+                    unstableThreshold: '1'
+                  ]
+                ],
+                tools: [
+                  [
+                    $class: 'JUnitType',
+                    pattern: 'test-reports/karma.xml'
+                  ]
+                ]
+              ])
+            }
+          }
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      // Destroy built site
+      script {
+        if (params.DESTROY_SITE == true) {
+          echo 'Destroying built site...'
+          sh "civibuild destroy ${params.BUILDNAME} || true"
+        }
+      }
+    }
+    success {
+      sendBuildSuccessNotification()
+    }
+    failure {
+      sendBuildFailureNotification()
+    }
+  }
+}
+
+/*
+ * Sends a notification when the build starts
+ */
+def sendBuildStartdNotification() {
+  def message = 'Building ' + getBuildTargetLink() + '. ' + getReportLink()
+
+  sendHipchatNotification('YELLOW', message)
+}
+
+/*
+ * Sends a notification when the build is completed successfully
+ */
+def sendBuildSuccessNotification() {
+  def message = getBuildTargetLink() + ' built successfully. Time: $BUILD_DURATION. ' + getReportLink()
+  sendHipchatNotification('GREEN', message)
+}
+
+/*
+ * Sends a notification when the build fails
+ */
+def sendBuildFailureNotification() {
+  def message = 'Failed to build ' + getBuildTargetLink() + '. Time: $BUILD_DURATION. No. of failed tests: ${TEST_COUNTS,var=\"fail\"}. ' + getReportLink()
+  sendHipchatNotification('RED', message)
+}
+
+/*
+ * Sends a notification to Hipchat
+ */
+def sendHipchatNotification(String color, String message) {
+  hipchatSend color: color, message: message, notify: true
+}
+
+/*
+ * Returns a link to what is being built. If it's a PR, then it's a link to the pull request itself.
+ * If it's a branch, then it's a link in the format http://github.com/org/repo/tree/branch
+ */
+def getBuildTargetLink() {
+  if(buildIsForAPullRequest()) {
+    return "<a href=\"${env.CHANGE_URL}\">\"${env.CHANGE_TITLE}\"</a>"
+  }
+
+  return '<a href="' + getRepositoryUrlForBuildBranch() + '">"' + env.BRANCH_NAME + '"</a>'
+}
+
+/*
+ * Returns true if this build as triggered by a Pull Request.
+ */
+def buildIsForAPullRequest() {
+  return env.CHANGE_URL != null
+}
+
+/*
+ * Returns a URL pointing to branch currently being built
+ */
+def getRepositoryUrlForBuildBranch() {
+  def repositoryURL = env.GIT_URL
+  repositoryURL = repositoryURL.replace('.git', '')
+
+  return repositoryURL + '/tree/' + env.BRANCH_NAME
+}
+
+/*
+ * Returns the Blue Ocean build report URL for the current job
+ */
+def getReportLink() {
+ return 'Click <a href="$BLUE_OCEAN_URL">here</a> to see the build report'
+}
+
+def cloneRepositories(String envBranch) {
+  for (repo in listRepositories()) {
+    sh """
+      git clone ${repo.url} ${repo.folder}
+      cd ${repo.folder}
+      git checkout $envBranch || true
+    """
+  }
+}
+
+def checkoutPrBranchInRepositories(String branch) {
+  echo 'Checking out PR branch'
+
+  for (repo in listRepositories()) {
+    sh """
+      cd ${repo.folder}
+      git checkout ${branch} || true
+    """
+  }
+}
+
+def mergeEnvBranchInAllRepositories(String envBranch) {
+  echo 'Merging env branch'
+
+  for (repo in listRepositories()) {
+    sh """
+      cd ${repo.folder}
+      git merge origin/${envBranch} --no-edit || true
+    """
+  }
+}
+
+/*
+ * Returns the T&A repository and the repositories of its dependencies.
+ *
+ * Note: T&A doesn't really dependent on CiviHR. It only depends on the
+ * reqangular extension which, at the moment, is in the CiviHR repository
+ */
+def listRepositories() {
+  return [
+    [
+      'url': 'https://github.com/civicrm/civihr.git',
+      'folder': "$CIVICRM_EXT_ROOT/civihr"
+    ],
+    [
+      'url': 'https://github.com/compucorp/civihr-tasks-assignments.git',
+      'folder': "$CIVICRM_EXT_ROOT/civihr_tasks"
+    ]
+  ]
+}
+
+/*
+ * Installs the T&A extension and its dependencies
+ */
+def installExtensionAndDependencies() {
+  sh """
+    cd $WEBROOT
+    drush cvapi extension.refresh
+    drush cvapi extension.install keys=org.civicrm.reqangular
+    drush cvapi extension.install keys=uk.co.compucorp.civicrm.tasksassignments
+  """
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -943,7 +943,7 @@ class CRM_Tasksassignments_Reminder {
   /**
    * Loads civicrm_uf_match data based on passed contact_id
    *
-   * @param $contact_id
+   * @param int $contact_id
    *
    * @return mixed
    *

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -638,8 +638,7 @@ class CRM_Tasksassignments_Reminder {
   public static function createActivityURL($contactId = NULL, $activityResultId = NULL) {
 
     if ($contactId) {
-      $activityUrl = '';
-      $drupal_user = user_load(_get_uf_match_contact($contactId)['uf_id']);
+      $drupal_user = user_load(self::getUfMatchContact($contactId)['uf_id']);
 
       if (user_access('access CiviCRM', $drupal_user)) {
         $activityUrl = CIVICRM_UF_BASEURL . '/civicrm/activity/view?action=view&reset=1&id=' . $activityResultId . '&cid=' . $contactId . '&context=activity&searchContext=activity';
@@ -662,7 +661,7 @@ class CRM_Tasksassignments_Reminder {
   public static function createContactURL($contactId = NULL) {
 
     if ($contactId) {
-      $drupal_user = user_load(_get_uf_match_contact($contactId)['uf_id']);
+      $drupal_user = user_load(self::getUfMatchContact($contactId)['uf_id']);
 
       if (user_access('access CiviCRM', $drupal_user)) {
         $contactUrl = CIVICRM_UF_BASEURL . '/civicrm/contact/view?reset=1&cid=' . $contactId;
@@ -939,6 +938,29 @@ class CRM_Tasksassignments_Reminder {
     $result = CRM_Utils_Mail::send($mailParams);
 
     return $result;
+  }
+
+  /**
+   * Loads civicrm_uf_match data based on passed contact_id
+   *
+   * @param $contact_id
+   *
+   * @return mixed
+   *
+   * @throws CiviCRM_API3_Exception
+   */
+  private static function getUfMatchContact($contact_id) {
+    $params = [
+      'contact_id' => $contact_id,
+      'version' => 3,
+      'sequential' => 1,
+    ];
+
+    // Get the "civicrm_uf_match" data from the passed target contact ID
+    $res = civicrm_api3('UFMatch', 'Get', $params);
+    $uf_match_data = array_shift($res['values']);
+
+    return $uf_match_data;
   }
 
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/gulpfile.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/gulpfile.js
@@ -6,6 +6,7 @@ var karma = require('karma');
 var exec = require('child_process').exec;
 var path = require('path');
 var fs = require('fs');
+var argv = require('yargs').argv;
 
 gulp.task('sass', function (done) {
   // The app style relies on compass's gems, so we need to rely on it
@@ -47,8 +48,11 @@ var test = (function () {
    * @param {Function} cb - The callback to call when the server closes
    */
   function runServer (configFile, cb) {
+    var reporters = argv.reporters ? argv.reporters.split(',') : ['progress'];
+
     new karma.Server({
       configFile: path.join(__dirname, '/js/', configFile),
+      reporters: reporters,
       singleRun: true
     }, function () {
       cb && cb();

--- a/uk.co.compucorp.civicrm.tasksassignments/js/karma.conf.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/karma.conf.js
@@ -66,6 +66,11 @@ module.exports = function (config) {
           '--remote-debugging-port=9222'
         ]
       }
+    },
+    junitReporter: {
+      outputDir: extPath + '/test-reports',
+      useBrowserName: false,
+      outputFile: 'karma.xml'
     }
   });
 };

--- a/uk.co.compucorp.civicrm.tasksassignments/js/karma.conf.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/karma.conf.js
@@ -1,7 +1,8 @@
+var cv = require('civicrm-cv')({ mode: 'sync' });
+
 module.exports = function (config) {
-  var civicrmPath = '../../../../../';
-  var civihrPath = 'tools/extensions/civihr/';
-  var extPath = 'tools/extensions/civihr_tasks/uk.co.compucorp.civicrm.tasksassignments/';
+  var civicrmPath = cv("path -d '[civicrm.root]'")[0].value;
+  var extPath = cv('path -x uk.co.compucorp.civicrm.tasksassignments')[0].value;
 
   config.set({
     basePath: civicrmPath,
@@ -20,36 +21,36 @@ module.exports = function (config) {
       'js/crm.ajax.js',
 
       // Global variables that need to be accessible in the test environment
-      extPath + 'js/test/globals.js',
+      extPath + '/js/test/globals.js',
 
       // manual loading of requirejs as to avoid interference with the global dependencies above
-      extPath + 'node_modules/requirejs/require.js',
-      extPath + 'node_modules/karma-requirejs/lib/adapter.js',
+      extPath + '/node_modules/requirejs/require.js',
+      extPath + '/node_modules/karma-requirejs/lib/adapter.js',
 
       // all the common/ dependencies
-      civihrPath + 'org.civicrm.reqangular/dist/reqangular.min.js',
+      cv('path -x org.civicrm.reqangular/dist/reqangular.min.js')[0].value,
 
       // the application modules
-      { pattern: extPath + 'js/src/tasks-assignments/**/*.js', included: false },
+      { pattern: extPath + '/js/src/tasks-assignments/**/*.js', included: false },
 
       // the mocked components files
-      { pattern: extPath + 'js/test/mocks/**/*.js', included: false },
+      { pattern: extPath + '/js/test/mocks/**/*.js', included: false },
 
       // the test files
-      { pattern: extPath + 'js/test/**/*.spec.js', included: false },
+      { pattern: extPath + '/js/test/**/*.spec.js', included: false },
 
       // angular templates
-      extPath + 'views/**/*.html',
+      extPath + '/views/**/*.html',
 
       // the requireJS config file that bootstraps the whole test suite
-      extPath + 'js/test/test-main.js'
+      extPath + '/js/test/test-main.js'
     ],
     exclude: [
-      extPath + 'js/src/tasks-assignments.js'
+      extPath + '/js/src/tasks-assignments.js'
     ],
     // Used to transform angular templates in JS strings
     preprocessors: (function (obj) {
-      obj[extPath + 'views/**/*.html'] = ['ng-html2js'];
+      obj[extPath + '/views/**/*.html'] = ['ng-html2js'];
       return obj;
     })({}),
     ngHtml2JsPreprocessor: {

--- a/uk.co.compucorp.civicrm.tasksassignments/js/karma.conf.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/karma.conf.js
@@ -5,7 +5,7 @@ module.exports = function (config) {
 
   config.set({
     basePath: civicrmPath,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
     frameworks: ['jasmine'],
     files: [
       // the global dependencies
@@ -55,6 +55,17 @@ module.exports = function (config) {
     ngHtml2JsPreprocessor: {
       prependPrefix: '/base/',
       moduleName: 'tasks-assignments.templates'
+    },
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: [
+          '--headless',
+          '--disable-gpu',
+          // Without a remote debugging port, Google Chrome exits immediately.
+          '--remote-debugging-port=9222'
+        ]
+      }
     }
   });
 };

--- a/uk.co.compucorp.civicrm.tasksassignments/package.json
+++ b/uk.co.compucorp.civicrm.tasksassignments/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/compucorp/civihr-tasks-assignments/issues"
   },
   "devDependencies": {
+    "civicrm-cv": "^0.1.2",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.4.0",
     "gulp-rename": "^1.2.2",

--- a/uk.co.compucorp.civicrm.tasksassignments/package.json
+++ b/uk.co.compucorp.civicrm.tasksassignments/package.json
@@ -19,9 +19,11 @@
     "karma": "^2.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-jasmine": "^1.1.1",
+    "karma-junit-reporter": "^1.2.0",
     "karma-ng-html2js-preprocessor": "^1.0.0",
     "karma-requirejs": "^1.1.0",
     "path": "^0.12.7",
-    "requirejs": "^2.3.5"
+    "requirejs": "^2.3.5",
+    "yargs": "^11.0.0"
   }
 }


### PR DESCRIPTION
## Overview

This PRs adds the necessary changes in order for Jenkins to run the T&A tests.

## Before

Jenkins couldn't run the extension's tests

## After

Jenkins can run the extension's tests. The same way as it works for CiviHR, it will run the tests in these specific scenarios:

- a PR has the `ready to test` label
- a merge is merged to `staging` or `master`.

Notifications are sent when a build starts, fails and/or finishes. Since we don't have a specific room for the T&A project on hipchat, they will be sent to the CiviHR room.

## Technical Details

The Jenkinsfile added here was heavily based on the [CiviHR one](https://github.com/civicrm/civihr/blob/staging/Jenkinsfile). However, since we have a single extension to be tested here, all the code related to looping through a list of extensions was removed.

T&A is supposed to be a standalone extension and to not depend on anything from CiviHR. However, as it's possible to see [here](https://github.com/compucorp/civihr-tasks-assignments/blob/767caf48b53cfee4a3140d09e64f8704f1dde52d/uk.co.compucorp.civicrm.tasksassignments/js/karma.conf.js#L31) it depends on reqangular, an generic utility library extension that, currently, is in the CiviHR repo. For that reason, in order to run the tests, we need to clone the civihr repo and install reqangular (but not the other CiviHR extensions).

While working on this, I also noticed that the extension had a dependency on the [SSP](https://github.com/compucorp/civihr-employee-portal) module. There were two places using the [_get_uf_match_contact()](https://github.com/compucorp/civihr-employee-portal/blob/staging/civihr_employee_portal/civihr_employee_portal.module#L1755-L1776) function. To remove the dependency, I simply copied the function from the SSP to the place where it is used by the extension. This was done on 767caf4.

Another issue I found while working on this was some hardcoded paths in the karma configuration file. I replace them with calls to `cv()`. This was done in cc4b766. Unfortunately, I was not able to remove all the hardcoded paths in JS files. There is still one ocurrence of that in the [globals.js file](https://github.com/compucorp/civihr-tasks-assignments/blob/staging/uk.co.compucorp.civicrm.tasksassignments/js/test/globals.js#L10). Since this is not a file loaded by node (it's injected by karma into the browser used to run the JS tests), we cannot use the `cv()` command there and I couldn't find any easy way to pass a dynamic file path to it. This means that, currently, to run the JS tests, T&A needs to always be installed inside that hardcoded path. Otherwise it won't be able to load the necessary files.

Finally, to be able to run the JS tests with Jenkins, the karma file had to be updated to use Chrome in Headless mode. This was done in fc82fc7