### PR TITLE
PCHR-3353: Set Custom Groups to Reserved

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -712,6 +712,21 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     return TRUE;
   }
 
+    /**
+     * Upgrade CustomGroup, setting Probation and Activity_Custom_Fields to is_reserved Yes
+     * @return bool
+     */
+  public function upgrade_1032() {
+      $result = civicrm_api3('CustomGroup', 'get', [
+          'sequential' => 1,
+          'return' => ["id"],
+          'name' => ['IN' => ["Probation", "Activity_Custom_Fields"]],
+          'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 1],
+      ]);
+
+      return true;
+  }
+
   public function uninstall() {
     CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard_tasks', 'ta_dashboard_documents', 'ta_dashboard_calendar', 'ta_dashboard_keydates', 'tasksassignments_administer', 'ta_settings')");
     CRM_Core_BAO_Navigation::resetNavigation();

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -718,12 +718,18 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
    * @return bool
    */
   public function upgrade_1032() {
-    civicrm_api3('CustomGroup', 'get', [
+    $result = civicrm_api3('CustomGroup', 'get', [
       'sequential' => 1,
       'return' => ['id'],
       'name' => ['IN' => ['Probation', 'Activity_Custom_Fields']],
-      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
     ]);
+    
+    foreach ($result['values'] as $value) {
+      civicrm_api3('CustomGroup', 'create', [
+        'id' => $value['id'],
+        'is_reserved' => 1,
+      ]);
+    }
 
     return TRUE;
   }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -712,19 +712,20 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     return TRUE;
   }
 
-    /**
-     * Upgrade CustomGroup, setting Probation and Activity_Custom_Fields to is_reserved Yes
-     * @return bool
-     */
+  /**
+   * Upgrade CustomGroup, setting Probation and Activity_Custom_Fields to is_reserved Yes
+   *
+   * @return bool
+   */
   public function upgrade_1032() {
-      $result = civicrm_api3('CustomGroup', 'get', [
-          'sequential' => 1,
-          'return' => ["id"],
-          'name' => ['IN' => ["Probation", "Activity_Custom_Fields"]],
-          'api.CustomGroup.create' => ['id' => "\$value.id", 'is_reserved' => 1],
-      ]);
+    civicrm_api3('CustomGroup', 'get', [
+      'sequential' => 1,
+      'return' => ['id'],
+      'name' => ['IN' => ['Probation', 'Activity_Custom_Fields']],
+      'api.CustomGroup.create' => ['id' => '\$value.id', 'is_reserved' => 1],
+    ]);
 
-      return true;
+    return TRUE;
   }
 
   public function uninstall() {


### PR DESCRIPTION
## Overview
This PR sets custom field groups that should not be editable to "is_reserved"=yes for the following custom groups.

- Activity Custom Fields
- Probation


## Before
![custom_group_before](https://user-images.githubusercontent.com/1507645/36677311-1c481bea-1b0e-11e8-9b75-93adcf79aab1.png)

## After
![custom_group_after_2](https://user-images.githubusercontent.com/1507645/36683333-95d490a6-1b1d-11e8-8fb2-03974659f1e8.png)


