### PR TITLE
PCHR-3040: Change the Workflow help text

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -269,6 +269,26 @@ function tasksassignments_civicrm_navigationMenu(&$params) {
 }
 
 /**
+ * Implements the alterAngular hook so it can modify the template for the
+ * Workflow Create/Edit screen.
+ *
+ * @param \Civi\Angular\Manager $angular
+ *
+ * @return \Civi\Angular\ChangeSet
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/framework/angular/changeset/
+ */
+function tasksAssignments_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
+  $changeSet = \Civi\Angular\ChangeSet::create('Workflow Modifications');
+
+  $changeSet->alterHtml('~/crmCaseType/edit.html', function (phpQueryObject $doc) {
+    _tasksAssignments_change_workflow_help_text($doc);
+  });
+
+  $angular->add($changeSet);
+}
+
+/**
  * Moves some of the items of the "Administer > Civi Case" sub menu under the "Administer > Tasks" sub menu
  *
  * @param array $params
@@ -411,30 +431,20 @@ function tasksassignments_extensionsPageRedirect()  {
 }
 
 /**
- * Implements the alterAngular hook so it can modify the template for the
- * Workflow Create/Edit screen.
- *
- * @param \Civi\Angular\Manager $angular
- * @return \Civi\Angular\ChangeSet
- */
-function tasksAssignments_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
-  $changeSet = \Civi\Angular\ChangeSet::create('Workflow Modifications');
-
-  $changeSet->alterHtml('~/crmCaseType/edit.html', function (phpQueryObject $doc) {
-    _tasksAssignments_civicrm_alterAngular_change_workflow_help_text($doc);
-  });
-
-  $angular->add($changeSet);
-}
-
-/**
  * Modifies the help text for the Workflow Create/Edit screen.
  *
  * @param phpQueryObject $doc
  */
-function _tasksAssignments_civicrm_alterAngular_change_workflow_help_text(phpQueryObject $doc) {
-  $text = '<p>' . ts('Configure your workflow timelines below. Each workflow type can have several different task timelines. Each timeline allows you to set different tasks and documents which become part of your task list on your task dashboard. As such different timelines can be setup in the system if slightly different steps are required when the workflow is used for different staff types or situations. For example you may wish to configure a different joining timeline for head office staff as for regional staff.') . '</p>';
-  $text .= '<p>' . ts('Workflows are normally used to manage joining and exiting processes but can be used for other processes too, such as a person going on maternity leave or moving region or location.') . '</p>';
+function _tasksAssignments_change_workflow_help_text(phpQueryObject $doc) {
+  $text = '<p>' . ts('Configure your workflow timelines below. Each workflow type can have several
+    different task timelines. Each timeline allows you to set different tasks and documents which
+    become part of your task list on your task dashboard. As such different timelines can be setup
+    in the system if slightly different steps are required when the workflow is used for different
+    staff types or situations. For example you may wish to configure a different joining timeline
+    for head office staff as for regional staff.') . '</p>';
+  $text .= '<p>' . ts('Workflows are normally used to manage joining and exiting processes but can
+    be used for other processes too, such as a person going on maternity leave or moving region or
+    location.') . '</p>';
 
   $doc->find('.crmCaseType .help')->html($text);
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -281,7 +281,7 @@ function _tasksassignments_moveCiviCaseAdminSubMenuItemsUnderTaskAdminSubMenu(&$
     'Case Types' => 'Workflows',
     'Case Statuses' => 'Workflows Status'
   ]);
-  
+
   _tasksassignments_deleteAdministerSubMenu($administerMenuItems, 'CiviCase');
 }
 
@@ -331,7 +331,7 @@ function _tasksassignments_cloneMenuItemsInAdministerSubMenuAndChangeLabels(&$ad
 
   foreach ($menuItems as $item) {
     $itemID = $item['attributes']['navID'];
-    $item['attributes']['parentID'] = $subMenuTargetID; 
+    $item['attributes']['parentID'] = $subMenuTargetID;
 
     if ($labelsMapping[$item['attributes']['name']]) {
       $item['attributes']['label'] = $labelsMapping[$item['attributes']['name']];
@@ -344,7 +344,7 @@ function _tasksassignments_cloneMenuItemsInAdministerSubMenuAndChangeLabels(&$ad
 /**
  * Deletes a sub menu of the given name from the Administer main menu
  *
- * @param array $administerMenuItems 
+ * @param array $administerMenuItems
  * @param string $subMenuName
  */
 function _tasksassignments_deleteAdministerSubMenu(&$administerMenuItems, $subMenuName) {
@@ -408,4 +408,33 @@ function tasksassignments_extensionsPageRedirect()  {
     ])
   );
   CRM_Utils_System::redirect($url);
+}
+
+/**
+ * Implements the alterAngular hook so it can modify the template for the
+ * Workflow Create/Edit screen.
+ *
+ * @param \Civi\Angular\Manager $angular
+ * @return \Civi\Angular\ChangeSet
+ */
+function tasksAssignments_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
+  $changeSet = \Civi\Angular\ChangeSet::create('Workflow Modifications');
+
+  $changeSet->alterHtml('~/crmCaseType/edit.html', function (phpQueryObject $doc) {
+    _tasksAssignments_civicrm_alterAngular_change_workflow_help_text($doc);
+  });
+
+  $angular->add($changeSet);
+}
+
+/**
+ * Modifies the help text for the Workflow Create/Edit screen.
+ *
+ * @param phpQueryObject $doc
+ */
+function _tasksAssignments_civicrm_alterAngular_change_workflow_help_text(phpQueryObject $doc) {
+  $text = '<p>' . ts('Configure your workflow timelines below. Each workflow type can have several different task timelines. Each timeline allows you to set different tasks and documents which become part of your task list on your task dashboard. As such different timelines can be setup in the system if slightly different steps are required when the workflow is used for different staff types or situations. For example you may wish to configure a different joining timeline for head office staff as for regional staff.') . '</p>';
+  $text .= '<p>' . ts('Workflows are normally used to manage joining and exiting processes but can be used for other processes too, such as a person going on maternity leave or moving region or location.') . '</p>';
+
+  $doc->find('.crmCaseType .help')->html($text);
 }


### PR DESCRIPTION
## Overview
This PR changes the help text for the Workflow Create and Edit screen.

## Before
![workflow-help-text-old](https://user-images.githubusercontent.com/1642119/36906076-5be62cb0-1e0b-11e8-9fb1-0aa6b18b1fe8.png)


## After
![workflow-help-text-new](https://user-images.githubusercontent.com/1642119/36905908-eba04864-1e0a-11e8-9a31-351543eb7225.png)


## Technical Details

The CiviCRM's [alterAngular hook](https://docs.civicrm.org/dev/en/latest/framework/angular/changeset/) was implemented so it changes the workflow's help text:

```php
// modifies the workflow's edit.html template:
function tasksAssignments_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
  $changeSet = \Civi\Angular\ChangeSet::create('Workflow Modifications');

  $changeSet->alterHtml('~/crmCaseType/edit.html', function (phpQueryObject $doc) {
    _tasksAssignments_civicrm_alterAngular_change_workflow_help_text($doc);
  });

  $angular->add($changeSet);
}

// changes the help text:
function _tasksAssignments_civicrm_alterAngular_change_workflow_help_text(phpQueryObject $doc) {
  $text = '<p>' . ts('paragraph #1') . '</p>';
  $text .= '<p>' . ts('paragraph #2') . '</p>';

  $doc->find('.crmCaseType .help')->html($text);
}
```

