### PR TITLE
PCHR-3402: Remove non relevant tabs from the Workflow configuration screen

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -283,6 +283,7 @@ function tasksAssignments_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
 
   $changeSet->alterHtml('~/crmCaseType/edit.html', function (phpQueryObject $doc) {
     _tasksAssignments_change_workflow_help_text($doc);
+    _tasksAssignments_remove_non_civihr_tabs_from_workflow($doc);
   });
 
   $angular->add($changeSet);
@@ -447,4 +448,18 @@ function _tasksAssignments_change_workflow_help_text(phpQueryObject $doc) {
     location.') . '</p>';
 
   $doc->find('.crmCaseType .help')->html($text);
+}
+
+/**
+ * Removes tabs that are not relevant for CiviHR from the workflow configuration screen.
+ *
+ * @param phpQueryObject $doc
+ */
+function _tasksAssignments_remove_non_civihr_tabs_from_workflow (phpQueryObject $doc) {
+  $tabs = ['roles', 'statuses', 'actType'];
+
+  foreach ($tabs as $tab) {
+    $doc->find('a[href=#acttab-' . $tab . ']')->remove();
+    $doc->find('#acttab-' . $tab)->remove();
+  }
 }


### PR DESCRIPTION
## Overview

This PR removes tabs that are not relevant to CiviHR from the Workflow configuration. These tabs are:

* Workflow roles,
* Workflow statuses, and
* Activity types.

## Before

![new workflow type hr17 9000](https://user-images.githubusercontent.com/1642119/36970319-8cd86376-203e-11e8-8e39-df00b0f596a4.png)

## After

![new workflow type hr17 9000 1](https://user-images.githubusercontent.com/1642119/36970383-caf6bd24-203e-11e8-93a7-63ec1bd4d254.png)


## Technical details

The alter angular hook was used to remove the tabs defined in the workflow configuration screen:

```php
function tasksAssignments_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
  $changeSet = \Civi\Angular\ChangeSet::create('Workflow Modifications');

  $changeSet->alterHtml('~/crmCaseType/edit.html', function (phpQueryObject $doc) {
    _tasksAssignments_change_workflow_help_text($doc);
    _tasksAssignments_remove_non_civihr_tabs_from_workflow($doc); // <--- here
  });

  $angular->add($changeSet);
}

function _tasksAssignments_remove_non_civihr_tabs_from_workflow (phpQueryObject $doc) {
  $tabs = ['roles', 'statuses', 'actType'];

  foreach ($tabs as $tab) {
    $doc->find('a[href=#acttab-' . $tab . ']')->remove(); // removes the tab link
    $doc->find('#acttab-' . $tab)->remove(); // removes the tab content
  }
}
```

As a reference, this is the template being edited: [template](https://github.com/civicrm/civicrm-core/blob/master/ang/crmCaseType/edit.html#L18)
