### PR TITLE
PCHR-3403: Allow only the "Add timeline" action

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -438,6 +438,8 @@ function tasksassignments_extensionsPageRedirect()  {
  * @param phpQueryObject $doc
  */
 function _tasksAssignments_change_workflow_help_text(phpQueryObject $doc) {
+  $helpBlock = $doc->find('.crmCaseType .help');
+
   $text = '<p>' . ts('Configure your workflow timelines below. Each workflow type can have several
     different task timelines. Each timeline allows you to set different tasks and documents which
     become part of your task list on your task dashboard. As such different timelines can be setup
@@ -448,7 +450,9 @@ function _tasksAssignments_change_workflow_help_text(phpQueryObject $doc) {
     be used for other processes too, such as a person going on maternity leave or moving region or
     location.') . '</p>';
 
-  $doc->find('.crmCaseType .help')->html($text);
+  $helpBlock->html($text);
+  // Places the help text outside of the case type form:
+  $helpBlock->insertBefore('.crmCaseType');
 }
 
 /**

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -284,6 +284,7 @@ function tasksAssignments_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
   $changeSet->alterHtml('~/crmCaseType/edit.html', function (phpQueryObject $doc) {
     _tasksAssignments_change_workflow_help_text($doc);
     _tasksAssignments_remove_non_civihr_tabs_from_workflow($doc);
+    _tasksAssignments_allow_only_add_timeline_action($doc);
   });
 
   $angular->add($changeSet);
@@ -462,4 +463,23 @@ function _tasksAssignments_remove_non_civihr_tabs_from_workflow (phpQueryObject 
     $doc->find('a[href=#acttab-' . $tab . ']')->remove();
     $doc->find('#acttab-' . $tab)->remove();
   }
+}
+
+/**
+ * Removes the Workflow configuration's actions dropdown and replaces it with a
+ * button that only allows the "Add timeline" action.
+ *
+ * @param phpQueryObject $doc
+ */
+function _tasksAssignments_allow_only_add_timeline_action (phpQueryObject $doc) {
+  $actionDropdown = $doc->find('select[ng-model="newActivitySetWorkflow"]');
+  $addTimelineBtn = '
+    <button class="btn btn-secondary pull-right"
+      ng-show="isNewActivitySetAllowed(\'timeline\')"
+      ng-click="addActivitySet(\'timeline\')">
+      Add timeline
+    </button>';
+
+  $actionDropdown->after($addTimelineBtn);
+  $actionDropdown->remove();
 }


### PR DESCRIPTION
## Overview
This PR fixes the following issues:

* Replaces the actions dropdown with a single button for the "Add timeline" action.
* Moves the help text outside of the case type form.

## Before
![new workflow type hr17 9000 3](https://user-images.githubusercontent.com/1642119/36972343-24e37858-2045-11e8-8a10-283219914f2d.png)

## After
![new workflow type hr17 9000 9](https://user-images.githubusercontent.com/1642119/37029961-91eedb66-210f-11e8-8441-09fe681dbe0e.png)

## Technical Details

### Add timeline action

The CiviCRM's alter angular hook was implemented in order to replace the dropdown:

```php
function tasksAssignments_civicrm_alterAngular(\Civi\Angular\Manager $angular) {
  $changeSet = \Civi\Angular\ChangeSet::create('Workflow Modifications');

  $changeSet->alterHtml('~/crmCaseType/edit.html', function (phpQueryObject $doc) {
    _tasksAssignments_change_workflow_help_text($doc);
    _tasksAssignments_remove_non_civihr_tabs_from_workflow($doc);
    _tasksAssignments_allow_only_add_timeline_action($doc); // <--- here
  });

  $angular->add($changeSet);
}

function _tasksAssignments_allow_only_add_timeline_action (phpQueryObject $doc) {
  $actionDropdown = $doc->find('select[ng-model="newActivitySetWorkflow"]');
  $addTimelineBtn = '
    <button class="btn btn-secondary pull-right"
      ng-show="isNewActivitySetAllowed(\'timeline\')"
      ng-click="addActivitySet(\'timeline\')">
      Add timeline
    </button>';

  $actionDropdown->after($addTimelineBtn); // adds the new button
  $actionDropdown->remove(); // removes the previous action dropdown
}
```

the `ng-show="isNewActivitySetAllowed('timeline')"` is there because:

1. The previous actions dropdown had it defined for the add timeline and add sequence actions ([here](https://github.com/civicrm/civicrm-core/blob/master/ang/crmCaseType/edit.html#L34)).
2. Because this CiviCRM function can determine if adding a new timeline is allowed, although for now [it always returns true](https://github.com/civicrm/civicrm-core/blob/master/ang/crmCaseType.js#L281) this might change in the future:

```js
$scope.isNewActivitySetAllowed = function(workflow) {
  switch (workflow) {
    case 'timeline':
      return true; // <--- always returns true for the timeline.
    case 'sequence':
      return 0 === _.where($scope.caseType.definition.activitySets, {sequence: '1'}).length;
    default:
      CRM.console('warn', 'Denied access to unrecognized workflow: (' + workflow + ')');
      return false;
  }
};
```

### Moving the help text

The `change_workflow_help_text` function was modified so it moves the help text outside of the case type form:

```php
function _tasksAssignments_change_workflow_help_text(phpQueryObject $doc) {
  $helpBlock = $doc->find('.crmCaseType .help');

  $text = '<p>...</p>';
  $text .= '<p>...</p>';

  $helpBlock->html($text);
  // Places the help text outside of the case type form:
  $helpBlock->insertBefore('.crmCaseType'); // <---- here
}
```

