### PR TITLE
PCHR-3376: Update T&A Administer Menu Items

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -740,20 +740,23 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
    * @return bool
    */
   public function upgrade_1033() {
-    $params = ['return' => 'id', 'name' => 'tasksassignments_administer'];
-    $parentId = (int) civicrm_api3('Navigation', 'getvalue', $params);
-    $params = ['return' => 'id', 'name' => 'ta_settings'];
-    $taSettingsId = (int) civicrm_api3('Navigation', 'getvalue', $params);
     $permission = 'administer CiviCase';
+    $itemsToChange = ['tasksassignments_administer', 'ta_settings'];
 
-    // Update permissions
-    foreach ([$parentId, $taSettingsId] as $navId) {
-      $params = ['permission' => $permission, 'id' => $navId];
-      civicrm_api3('Navigation', 'create', $params);
-    }
+    // get item IDs
+    $params = ['name' => ['IN' => $itemsToChange]];
+    $itemsToChange = civicrm_api3('Navigation', 'get', $params);
+    $itemsToChange = array_column($itemsToChange['values'], 'name', 'id');
+    $tasksId = array_search('tasksassignments_administer', $itemsToChange);
+    $taSettingsId = array_search('ta_settings', $itemsToChange);
 
-    // Update parent weight
-    civicrm_api3('Navigation', 'create', ['id' => $parentId, 'weight' => -97]);
+    // Update permissions for settings item
+    $params = ['permission' => $permission, 'id' => $taSettingsId];
+    civicrm_api3('Navigation', 'create', $params);
+
+    // Update parent weight + permission
+    $params = ['id' => $tasksId, 'weight' => -97, 'permission' => $permission];
+    civicrm_api3('Navigation', 'create', $params);
 
     return TRUE;
   }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -723,13 +723,37 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
       'return' => ['id'],
       'name' => ['IN' => ['Probation', 'Activity_Custom_Fields']],
     ]);
-    
+
     foreach ($result['values'] as $value) {
       civicrm_api3('CustomGroup', 'create', [
         'id' => $value['id'],
         'is_reserved' => 1,
       ]);
     }
+
+    return TRUE;
+  }
+
+  /**
+   * Update permissions and set the weight for the "Tasks" menu item.
+   *
+   * @return bool
+   */
+  public function upgrade_1033() {
+    $params = ['return' => 'id', 'name' => 'tasksassignments_administer'];
+    $parentId = (int) civicrm_api3('Navigation', 'getvalue', $params);
+    $params = ['return' => 'id', 'name' => 'ta_settings'];
+    $taSettingsId = (int) civicrm_api3('Navigation', 'getvalue', $params);
+    $permission = 'administer CiviCase';
+
+    // Update permissions
+    foreach ([$parentId, $taSettingsId] as $navId) {
+      $params = ['permission' => $permission, 'id' => $navId];
+      civicrm_api3('Navigation', 'create', $params);
+    }
+
+    // Update parent weight
+    civicrm_api3('Navigation', 'create', ['id' => $parentId, 'weight' => -97]);
 
     return TRUE;
   }

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -275,12 +275,18 @@ function tasksassignments_civicrm_navigationMenu(&$params) {
  */
 function _tasksassignments_moveCiviCaseAdminSubMenuItemsUnderTaskAdminSubMenu(&$params) {
   $administerMenuItems = &_tasksassignments_getAdministerMenuItems($params);
-  $menuItemsToClone = _tasksassignments_filterMenuItemsOfAdministerSubMenu($administerMenuItems, 'CiviCase', ['Case Types', 'Case Statuses']);
+  $menuItemsToClone = _tasksassignments_filterMenuItemsOfAdministerSubMenu(
+    $administerMenuItems,
+    'CiviCase',
+    ['Case Types']
+  );
 
-  _tasksassignments_cloneMenuItemsInAdministerSubMenuAndChangeLabels($administerMenuItems, $menuItemsToClone, 'tasksassignments_administer', [
-    'Case Types' => 'Workflows',
-    'Case Statuses' => 'Workflows Status'
-  ]);
+  _tasksassignments_cloneMenuItemsInAdministerSubMenuAndChangeLabels(
+    $administerMenuItems,
+    $menuItemsToClone,
+    'tasksassignments_administer',
+    ['Case Types' => 'Workflows',]
+  );
   
   _tasksassignments_deleteAdministerSubMenu($administerMenuItems, 'CiviCase');
 }
@@ -323,7 +329,7 @@ function _tasksassignments_filterMenuItemsOfAdministerSubMenu($administerMenuIte
  *
  * @param array $administerMenuItems
  * @param array $menuItems
- * @param array $subMenuName
+ * @param string $subMenuName
  * @param array $labelsMapping
  */
 function _tasksassignments_cloneMenuItemsInAdministerSubMenuAndChangeLabels(&$administerMenuItems, $menuItems, $subMenuName, $labelsMapping) {


### PR DESCRIPTION
## Overview

We are changing what menu items can be accessed. T&A provides some items for the "Configure" submenu, and these will be altered.

## Before

![image](https://user-images.githubusercontent.com/6374064/37347692-5277ff06-26ca-11e8-86bd-0d2a71045f4c.png)

- T&A provided the "Tasks" submenu in the "Configure" menu but no items had permission set
- It cloned two items from the CiviCase submenu, which were relabled as "Workflows" and "Workflows Status"
- The weight of the "Tasks" item was not set and so it appears at the top of the list

## After

![image](https://user-images.githubusercontent.com/6374064/37347601-1962f5a4-26ca-11e8-96f0-98a7ec364565.png)

- The permission for all T&A menu items is `administer CiviCase`. 
- The "Workflows Status" menu item is no longer cloned. 
- The weight of "Tasks" has been set so it appears in the required order (before "Leave")