### PR TITLE
PCHR-3481: Bump version to 1.7.5

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/info.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/info.xml
@@ -10,7 +10,7 @@
   </maintainer>
   <releaseDate>2018-03-26</releaseDate>
   <version>1.7.5</version>
-  <develStage>alpha</develStage>
+  <develStage>stable</develStage>
   <compatibility>
     <ver>4.7</ver>
   </compatibility>

--- a/uk.co.compucorp.civicrm.tasksassignments/info.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/info.xml
@@ -8,8 +8,8 @@
     <author>Mateusz Cieplinski</author>
     <email>mateusz@coldrun.pl</email>
   </maintainer>
-  <releaseDate>2018-02-26</releaseDate>
-  <version>1.7.4</version>
+  <releaseDate>2018-03-26</releaseDate>
+  <version>1.7.5</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/uk.co.compucorp.civicrm.tasksassignments/info.xml
+++ b/uk.co.compucorp.civicrm.tasksassignments/info.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <extension key="uk.co.compucorp.civicrm.tasksassignments" type="module">
   <file>tasksassignments</file>
-  <name>Tasks and assignments</name>
-  <description>FIXME</description>
+  <name>Tasks and Workflows</name>
+  <description>Provides functionalities to manage Tasks and Workflows</description>
   <license>AGPL-3.0</license>
   <maintainer>
-    <author>Mateusz Cieplinski</author>
-    <email>mateusz@coldrun.pl</email>
+    <author>Compucorp Ltd</author>
+    <email>info@compucorp.co.uk</email>
   </maintainer>
   <releaseDate>2018-03-26</releaseDate>
   <version>1.7.5</version>
@@ -14,7 +14,6 @@
   <compatibility>
     <ver>4.7</ver>
   </compatibility>
-  <comments>This is a new, undeveloped module</comments>
   <civix>
     <namespace>CRM/Tasksassignments</namespace>
   </civix>


### PR DESCRIPTION
This includes:

- Bumping the version number
- Setting the develStage to `stable`
- Updating maintainer
- Updating extension name (a more complete update will be done in another chance)
- Removing placeholder text