### PR TITLE
PCHR-3416: Hide reserved activity types

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/Options.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/Options.php
@@ -3,11 +3,25 @@
 require_once 'CRM/Core/Page.php';
 
 class CRM_Tasksassignments_Page_Options extends CRM_Admin_Page_Options {
-  
+
   function run() {
     parent::run();
   }
-    
+
+  /**
+   * Browse all options.
+   */
+  public function browse() {
+    parent::browse();
+
+    $optionValues = $this->get_template_vars('rows');
+    $optionValues = array_filter($optionValues, function ($item) {
+      return $item['is_reserved'] == 0;
+    });
+
+    $this->assign('rows', $optionValues);
+  }
+
   /**
    * Use the form name to create the tpl file name
    *
@@ -20,7 +34,7 @@ class CRM_Tasksassignments_Page_Options extends CRM_Admin_Page_Options {
       'CRM_Admin_Page_Options'
     ) . '.tpl';
   }
-    
+
   function editForm() {
     //return self::$_gName ? 'CRM_Admin_Form_Options' : 'CRM_Admin_Form_OptionGroup';
     if (self::$_gName === 'activity_type') {


### PR DESCRIPTION
## Overview
As part of this PR the Reserved Activity Types are hidden from the UI.

## Before
![2018-04-09 at 3 10 pm](https://user-images.githubusercontent.com/5058867/38491032-6409d53e-3c08-11e8-876d-3c1e8df54445.png)


## After
![2018-04-09 at 3 06 pm](https://user-images.githubusercontent.com/5058867/38490771-a4d49654-3c07-11e8-974e-3722f6c506e8.png)

I am showing the count of Option Values for the Screenshots only. Its not part of the code.


## Technical Details
1. In `uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/Options.php`,
  - Overriding `browse` function to hide `is_reserved` option values.