### PR TITLE
PCHR-3405: Rename workflow statuses

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -714,10 +714,12 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
 
   /**
    * Renames the case status Ongoing and Resolved to In Progress and Completed.
+   *
+   * @return bool
    */
   public function upgrade_1032() {
-    $this->_renameCaseStatus('Ongoing', 'In Progress');
-    $this->_renameCaseStatus('Resolved', 'Completed');
+    $this->_relabelCaseStatus('Ongoing', 'In Progress');
+    $this->_relabelCaseStatus('Resolved', 'Completed');
 
     return TRUE;
   }
@@ -810,17 +812,20 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
    * @param string $fromLabel
    * @param string $toLabel
    */
-  private function _renameCaseStatus($fromLabel, $toLabel) {
-    $optionValue = civicrm_api3('OptionValue', 'getsingle', [
+  private function _relabelCaseStatus($fromLabel, $toLabel) {
+    $result = civicrm_api3('OptionValue', 'get', [
       'option_group_id.name' => 'case_status',
       'label' => $fromLabel,
       'is_reserved' => 1,
+      'sequential' => 1,
       'options' => [ 'limit' => 1 ],
     ]);
 
-    civicrm_api3('OptionValue', 'create', [
-      'id' => $optionValue['id'],
-      'label' => $toLabel
-    ]);
+    if ($result['count']) {
+      civicrm_api3('OptionValue', 'create', [
+        'id' => $result['values'][0]['id'],
+        'label' => $toLabel
+      ]);
+    }
   }
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -712,6 +712,16 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     return TRUE;
   }
 
+  /**
+   * Renames the case status Ongoing and Resolved to In Progress and Completed.
+   */
+  public function upgrade_1032() {
+    $this->_renameCaseStatus('Ongoing', 'In Progress');
+    $this->_renameCaseStatus('Resolved', 'Completed');
+
+    return TRUE;
+  }
+
   public function uninstall() {
     CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard_tasks', 'ta_dashboard_documents', 'ta_dashboard_calendar', 'ta_dashboard_keydates', 'tasksassignments_administer', 'ta_settings')");
     CRM_Core_BAO_Navigation::resetNavigation();
@@ -792,5 +802,25 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
     foreach ($typeIds as $id) {
       civicrm_api3('OptionValue', 'delete', array('id' => $id));
     }
+  }
+
+  /**
+   * Renames the label for a case status
+   *
+   * @param string $fromLabel
+   * @param string $toLabel
+   */
+  private function _renameCaseStatus($fromLabel, $toLabel) {
+    $optionValue = civicrm_api3('OptionValue', 'getsingle', [
+      'option_group_id.name' => 'case_status',
+      'label' => $fromLabel,
+      'is_reserved' => 1,
+      'options' => [ 'limit' => 1 ],
+    ]);
+
+    civicrm_api3('OptionValue', 'create', [
+      'id' => $optionValue['id'],
+      'label' => $toLabel
+    ]);
   }
 }


### PR DESCRIPTION
## Overview
This PR renames the following workflow statuses:

|From|to|
|----|--|
|Ongoing|In Progress|
|Resolved|Completed|

## Before
![case status options hr17 9200 1](https://user-images.githubusercontent.com/1642119/38491521-195198ea-3bba-11e8-8035-2403580ebf8d.png)

## After
![case status options hr17 9200](https://user-images.githubusercontent.com/1642119/38491289-7618b0a0-3bb9-11e8-9861-17e36ba819b7.png)

## Technical Details
A new upgrader was added to T&W:

```php
<?php

class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
{
  // ...
  public function upgrade_1032() {
    $this->_renameCaseStatus('Ongoing', 'In Progress');
    $this->_renameCaseStatus('Resolved', 'Completed');
    return TRUE;
  }

  private function _renameCaseStatus($fromLabel, $toLabel) {
    $optionValue = civicrm_api3('OptionValue', 'getsingle', [
      'option_group_id.name' => 'case_status',
      'label' => $fromLabel,
      'is_reserved' => 1,
      'options' => [ 'limit' => 1 ],
    ]);
    civicrm_api3('OptionValue', 'create', [
      'id' => $optionValue['id'],
      'label' => $toLabel
    ]);
  }
}
```
