### PR TITLE
PCHR-3571: Mark case as closed

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Task.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/BAO/Task.php
@@ -2,6 +2,7 @@
 
 class CRM_Tasksassignments_BAO_Task extends CRM_Tasksassignments_DAO_Task {
   const COMPLETED_STATUS = 'Completed';
+  const WORKFLOW_CATEGORY = 'WORKFLOW';
 
   /**
    * Create a new Task based on array-data
@@ -35,7 +36,7 @@ class CRM_Tasksassignments_BAO_Task extends CRM_Tasksassignments_DAO_Task {
     CRM_Tasksassignments_Reminder::sendReminder((int) $instance->id, NULL, FALSE, $previousAssigneeId);
 
     if ($hook === 'edit') {
-      $isWorkflowCaseCategory = 'WORKFLOW' === self::getCaseCategory($instance->case_id);
+      $isWorkflowCaseCategory = self::getCaseCategory($instance->case_id) === self::WORKFLOW_CATEGORY;
       $allCaseTasksAreCompleted = self::checkIfTasksBelongingToCaseAreCompleted($instance->case_id);
 
       if ($isWorkflowCaseCategory && $allCaseTasksAreCompleted) {
@@ -63,7 +64,7 @@ class CRM_Tasksassignments_BAO_Task extends CRM_Tasksassignments_DAO_Task {
 
     $case = civicrm_api3('Case', 'getsingle', [
       'id' => $caseId,
-      'return' => [ 'case_type_id.category.name' ]
+      'return' => ['case_type_id.category.name']
     ]);
 
     return $case['case_type_id.category.name'];

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Case.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Case.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Case Fabricator class
+ */
+class CRM_Tasksassignments_Test_Fabricator_Case {
+
+  /**
+   * Fabricates a Case.
+   *
+   * @param array $params
+   *   List of parameters to use to create the Case.
+   *   Array(
+   *     'contact_id' => int $contactId,
+   *     'creator_id' => int $contactId,
+   *     'case_type_id' => int $caseTypeValue
+   *     'subject' => string $subject
+   *   );
+   *
+   * @return array
+   */
+  public static function fabricate($params = []) {
+    $result = civicrm_api3('Case', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Case.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Case.php
@@ -4,6 +4,9 @@
  * Case Fabricator class
  */
 class CRM_Tasksassignments_Test_Fabricator_Case {
+  private static $defaultParams = [
+    'subject' => 'Sample Case'
+  ];
 
   /**
    * Fabricates a Case.
@@ -20,6 +23,7 @@ class CRM_Tasksassignments_Test_Fabricator_Case {
    * @return array
    */
   public static function fabricate($params = []) {
+    $params = array_merge($params, self::$defaultParams);
     $result = civicrm_api3('Case', 'create', $params);
 
     return array_shift($result['values']);

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/CaseType.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/CaseType.php
@@ -3,8 +3,27 @@
 class CRM_Tasksassignments_Test_Fabricator_CaseType {
 
   private static $defaultParams = [
-    'name' => 'test_case_type',
     'title' => 'Test Case Type',
+    'name' => 'test_case_type',
+    'category' => 1,
+    'is_active' => 1,
+    'sequential'   => 1,
+    'weight' => 100,
+    'definition' => [
+      'activityTypes' => [
+        ['name' => 'Test'],
+      ],
+      'activitySets' => [
+        [
+          'name' => 'set1',
+          'label' => 'Label 1',
+          'timeline' => 1,
+          'activityTypes' => [
+            ['name' => 'Open Case', 'status' => 'Completed'],
+          ],
+        ],
+      ],
+    ],
   ];
 
   /**
@@ -17,7 +36,7 @@ class CRM_Tasksassignments_Test_Fabricator_CaseType {
    * @return array
    */
   public static function fabricate($params = []) {
-    $params = array_merge($params, self::$defaultParams);
+    $params = array_merge(self::$defaultParams, $params);
     $result = civicrm_api3('CaseType', 'create', $params);
 
     return array_shift($result['values']);

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/CaseType.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/CaseType.php
@@ -5,7 +5,7 @@ class CRM_Tasksassignments_Test_Fabricator_CaseType {
   private static $defaultParams = [
     'title' => 'Test Case Type',
     'name' => 'test_case_type',
-    'category' => 1,
+    'category' => 'WORKFLOW',
     'is_active' => 1,
     'sequential'   => 1,
     'weight' => 100,

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/OptionGroup.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/OptionGroup.php
@@ -1,0 +1,28 @@
+<?php
+
+use CRM_Tasksassignments_Test_Fabricator_OptionValue as OptionValueFabricator;
+
+/**
+ * Option Group Fabricator class
+ */
+class CRM_Tasksassignments_Test_Fabricator_OptionGroup {
+  /**
+   * Fabricates an Option Group.
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  public static function fabricate($params = []) {
+    $result = civicrm_api3('OptionGroup', 'create', $params);
+
+    return array_shift($result['values']);
+  }
+
+  public static function fabricateCaseCategoryGroupAndValues() {
+    self::fabricate(['name' => 'case_type_category']);
+    OptionValueFabricator::fabricate([ 'name' => 'WORKFLOW', 'option_group_id' => 'case_type_category' ]);
+    OptionValueFabricator::fabricate([ 'name' => 'VACANCY', 'option_group_id' => 'case_type_category'  ]);
+  }
+
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/OptionValue.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/OptionValue.php
@@ -17,7 +17,7 @@ class CRM_Tasksassignments_Test_Fabricator_OptionValue {
    * @return array
    */
   public static function fabricate($params = []) {
-    $params = array_merge($params, self::$defaultParams);
+    $params = array_merge(self::$defaultParams, $params);
     $result = civicrm_api3('OptionValue', 'create', $params);
 
     return array_shift($result['values']);

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -210,7 +210,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
         ),
         'keydates_tab' => array(
           'label' => 'Show or hide the Key Dates tab',
-          'value' => 1,
+          'value' => 2,
         ),
         'add_assignment_button_title' => array(
           'label' => 'Configure \'Add Assignment\' button title',
@@ -398,7 +398,6 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base
         'option_group_id' => 'ta_settings',
         'name' => 'is_task_dashboard_default',
         'label' => 'Is task dashboard the default page',
-        'value' => '1'
       );
       civicrm_api3('OptionValue', 'create', $opValueParams);
     }

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Task.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Task.php
@@ -505,7 +505,8 @@ function civicrm_api3_task_get($params) {
   }
 
   if ($caseId) {
-    $caseActivityIds = array_keys(CRM_Case_BAO_Case::getCaseActivity($caseId));
+    $activities = CRM_Case_BAO_Case::getCaseActivity($caseId);
+    $caseActivityIds = array_column($activities['data'], 'DT_RowId');
     $activityIds = !empty($activityIds) ? array_intersect($activityIds, $caseActivityIds) : $caseActivityIds;
     if (empty($activityIds)) {
       $activityIds[] = 0;

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Task.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Task.php
@@ -15,7 +15,7 @@ use CRM_Activity_Service_ActivityService as ActivityService;
 function civicrm_api3_task_create($params) {
 
   if (!empty($params['task'])) {
-      return civicrm_api3_task_create_multiple($params);
+    return civicrm_api3_task_create_multiple($params);
   }
 
   if (empty($params['id'])) {
@@ -32,7 +32,6 @@ function civicrm_api3_task_create($params) {
   if (!empty($errors)) {
     return $errors;
   }
-
 
   $values = $activityArray = array();
   _civicrm_api3_custom_format_params($params, $values, 'Task');
@@ -124,73 +123,78 @@ function civicrm_api3_task_create($params) {
     _civicrm_api3_object_to_array($activityBAO, $activityArray[$activityBAO->id]);
     //return civicrm_api3_create_success($activityArray, $params, 'activity', 'get', $activityBAO);
     return civicrm_api3_task_get(array(
-        'sequential' => isset($params['sequential']) ? $params['sequential'] : 0,
-        'debug' => isset($params['debug']) ? $params['debug'] : 0,
-        'id' => $activityBAO->id
+      'sequential' => isset($params['sequential']) ? $params['sequential'] : 0,
+      'debug' => isset($params['debug']) ? $params['debug'] : 0,
+      'id' => $activityBAO->id,
     ));
   }
 }
 
 function civicrm_api3_task_copy_to_assignment($params) {
+  if (empty($params['id'])) {
+    throw new API_Exception(ts("Please specify 'id' value(s)."));
+  }
 
-    if (empty($params['id'])) {
-        throw new API_Exception(ts("Please specify 'id' value(s)."));
-    }
-    if (empty($params['case_id'])) {
-        throw new API_Exception(ts("Please specify 'case_id' value."));
-    }
+  if (empty($params['case_id'])) {
+    throw new API_Exception(ts("Please specify 'case_id' value."));
+  }
 
-    if (empty($params['sequential'])) {
-        $params['sequential'] = 0;
-    }
-    if (empty($params['debug'])) {
-        $params['debug'] = 0;
-    }
+  if (empty($params['sequential'])) {
+    $params['sequential'] = 0;
+  }
 
-    $ids = (array)$params['id'];
-    $caseId = (int)$params['case_id'];
-    $result = array();
-    foreach ($ids as $id) {
-        $taskToAssignment = array(
-          'sequential' => $params['sequential'],
-          'debug' => $params['debug'],
-          'id' => $id,
-          'case_id' => $caseId,
-        );
-        $createResult = civicrm_api3('Task', 'create', $taskToAssignment);
-        if ($createResult['count']) {
-            $result[] = array_shift($createResult['values']);
-        }
-    }
+  if (empty($params['debug'])) {
+    $params['debug'] = 0;
+  }
 
-    return civicrm_api3_create_success($result, $params);
+  $ids = (array) $params['id'];
+  $caseId = (int) $params['case_id'];
+  $result = array();
+
+  foreach ($ids as $id) {
+    $taskToAssignment = array(
+      'sequential' => $params['sequential'],
+      'debug' => $params['debug'],
+      'id' => $id,
+      'case_id' => $caseId,
+    );
+    $createResult = civicrm_api3('Task', 'create', $taskToAssignment);
+
+    if ($createResult['count']) {
+      $result[] = array_shift($createResult['values']);
+    }
+  }
+
+  return civicrm_api3_create_success($result, $params);
 }
 
 function civicrm_api3_task_create_multiple($params) {
+  if (empty($params['task'])) {
+    throw new API_Exception(ts("Please specify 'task' array."));
+  }
 
-    if (empty($params['task'])) {
-        throw new API_Exception(ts("Please specify 'task' array."));
-    }
+  if (empty($params['sequential'])) {
+    $params['sequential'] = 0;
+  }
 
-    if (empty($params['sequential'])) {
-        $params['sequential'] = 0;
-    }
-    if (empty($params['debug'])) {
-        $params['debug'] = 0;
-    }
+  if (empty($params['debug'])) {
+    $params['debug'] = 0;
+  }
 
-    $tasks = (array)$params['task'];
-    $result = array();
-    foreach ($tasks as $task) {
-        $task['sequential'] = $params['sequential'];
-        $task['debug'] = $params['debug'];
-        $createResult = civicrm_api3('Task', 'create', $task);
-        if ($createResult['count']) {
-            $result[] = array_shift($createResult['values']);
-        }
-    }
+  $tasks = (array) $params['task'];
+  $result = array();
 
-    return civicrm_api3_create_success($result, $params);
+  foreach ($tasks as $task) {
+    $task['sequential'] = $params['sequential'];
+    $task['debug'] = $params['debug'];
+    $createResult = civicrm_api3('Task', 'create', $task);
+
+    if ($createResult['count']) {
+      $result[] = array_shift($createResult['values']);
+    }
+  }
+
+  return civicrm_api3_create_success($result, $params);
 }
 
 /**
@@ -199,7 +203,6 @@ function civicrm_api3_task_create_multiple($params) {
  * @param array $params (reference) array of parameters determined by getfields
  */
 function _civicrm_api3_task_create_spec(&$params) {
-
   //default for source_contact_id = currently logged in user
   $params['source_contact_id']['api.default'] = 'user_contact_id';
 
@@ -219,11 +222,11 @@ function _civicrm_api3_task_create_spec(&$params) {
   );
 
   $params['source_contact_id'] = array(
-      'name' => 'source_contact_id',
-      'title' => 'Activity Source Contact',
-      'type' => 1,
-      'FKClassName' => 'CRM_Activity_DAO_ActivityContact',
-      'api.default' => 'user_contact_id',
+    'name' => 'source_contact_id',
+    'title' => 'Activity Source Contact',
+    'type' => 1,
+    'FKClassName' => 'CRM_Activity_DAO_ActivityContact',
+    'api.default' => 'user_contact_id',
   );
 
 }
@@ -239,10 +242,12 @@ function _civicrm_api3_task_create_spec(&$params) {
  */
 function _civicrm_api3_task_get_formatResult($params, $activities) {
   $returns = CRM_Utils_Array::value('return', $params, array());
+
   if (!is_array($returns)) {
     $returns = str_replace(' ', '', $returns);
     $returns = explode(',', $returns);
   }
+
   $returns = array_fill_keys($returns, 1);
 
   foreach ($params as $n => $v) {
@@ -251,7 +256,9 @@ function _civicrm_api3_task_get_formatResult($params, $activities) {
       $returns[$returnkey] = $v;
     }
   }
+
   $returns['source_contact_id'] = 1;
+
   foreach ($returns as $n => $v) {
     switch ($n) {
       case 'assignee_contact_id':
@@ -259,28 +266,33 @@ function _civicrm_api3_task_get_formatResult($params, $activities) {
           $activities[$key]['assignee_contact_id'] = CRM_Activity_BAO_ActivityAssignment::retrieveAssigneeIdsByActivityId($activityArray['id']);
         }
         break;
+
       case 'target_contact_id':
         foreach ($activities as $key => $activityArray) {
           $activities[$key]['target_contact_id'] = CRM_Activity_BAO_ActivityTarget::retrieveTargetIdsByActivityId($activityArray['id']);
         }
         break;
+
       case 'source_contact_id':
         foreach ($activities as $key => $activityArray) {
           $activities[$key]['source_contact_id'] = CRM_Activity_BAO_Activity::getSourceContactID($activityArray['id']);
         }
         break;
+
       default:
         if (substr($n, 0, 6) == 'custom') {
           $returnProperties[$n] = $v;
         }
     }
   }
+
   if (!empty($activities) && (!empty($returnProperties) || !empty($params['contact_id']))) {
     foreach ($activities as $activityId => $values) {
       //@todo - should possibly load activity type id if not loaded (update with id)
       _civicrm_api3_custom_data_get($activities[$activityId], 'Activity', $activityId, NULL, CRM_Utils_Array::value('activity_type_id', $values));
     }
   }
+
   return $activities;
 }
 
@@ -306,7 +318,7 @@ function civicrm_api3_task_delete($params) {
     throw new API_Exception('You don\'t have permissions to delete Tasks');
   }
 
-  CRM_Tasksassignments_Reminder::sendReminder($params['id'], null, false, null, true);
+  CRM_Tasksassignments_Reminder::sendReminder($params['id'], NULL, FALSE, NULL, TRUE);
   if (CRM_Activity_BAO_Activity::deleteActivity($params)) {
     return civicrm_api3_create_success(1, $params, 'activity', 'delete');
   }
@@ -327,24 +339,23 @@ function civicrm_api3_task_delete($params) {
  * @return array $error array with errors
  */
 function _civicrm_api3_task_check_params(&$params) {
-
-  $contactIDFields = array_intersect_key($params,
-                     array(
-                       'source_contact_id' => 1,
-                       'assignee_contact_id' => 1,
-                       'target_contact_id' => 1,
-                     )
-  );
+  $contactIDFields = array_intersect_key($params, array(
+    'source_contact_id' => 1,
+    'assignee_contact_id' => 1,
+    'target_contact_id' => 1,
+  ));
 
   // this should be handled by wrapper layer & probably the api would already manage it
   //correctly by doing post validation - ie. a failure should result in a roll-back = an error
   // needs testing
   if (!empty($contactIDFields)) {
     $contactIds = array();
+
     foreach ($contactIDFields as $fieldname => $contactfield) {
       if (empty($contactfield)) {
         continue;
       }
+
       if (is_array($contactfield)) {
         foreach ($contactfield as $contactkey => $contactvalue) {
           $contactIds[$contactvalue] = $contactvalue;
@@ -355,20 +366,20 @@ function _civicrm_api3_task_check_params(&$params) {
       }
     }
 
-
     $sql = '
 SELECT  count(*)
   FROM  civicrm_contact
  WHERE  id IN (' . implode(', ', $contactIds) . ' )';
+
     if (count($contactIds) != CRM_Core_DAO::singleValueQuery($sql)) {
       throw new API_Exception('Invalid ' .  ' Contact Id');
     }
   }
 
-
-  $activityIds = array('activity' => CRM_Utils_Array::value('id', $params),
-                 'parent' => CRM_Utils_Array::value('parent_id', $params),
-                 'original' => CRM_Utils_Array::value('original_id', $params),
+  $activityIds = array(
+    'activity' => CRM_Utils_Array::value('id', $params),
+    'parent' => CRM_Utils_Array::value('parent_id', $params),
+    'original' => CRM_Utils_Array::value('original_id', $params),
   );
 
   foreach ($activityIds as $id => $value) {
@@ -378,6 +389,7 @@ SELECT  count(*)
       throw new API_Exception('Invalid ' . ucfirst($id) . ' Id');
     }
   }
+
   // this should be handled by wrapper layer & probably the api would already manage it
   //correctly by doing pseudoconstant validation
   // needs testing
@@ -385,6 +397,7 @@ SELECT  count(*)
   $activityName  = CRM_Utils_Array::value('activity_name', $params);
   $activityName  = ucfirst($activityName);
   $activityLabel = CRM_Utils_Array::value('activity_label', $params);
+
   if ($activityLabel) {
     $activityTypes = CRM_Activity_BAO_Activity::buildOptions('activity_type_id', 'create');
   }
@@ -395,17 +408,17 @@ SELECT  count(*)
     $activityTypeIdInList = array_search(($activityName ? $activityName : $activityLabel), $activityTypes);
 
     if (!$activityTypeIdInList) {
-      $errorString = $activityName ? "Invalid Activity Name : $activityName"  : "Invalid Activity Type Label";
+      $errorString = $activityName ? "Invalid Activity Name : $activityName" : "Invalid Activity Type Label";
+
       throw new Exception($errorString);
     }
     elseif ($activityTypeId && ($activityTypeId != $activityTypeIdInList)) {
       throw new API_Exception('Mismatch in Activity');
     }
+
     $params['activity_type_id'] = $activityTypeIdInList;
   }
-  elseif ($activityTypeId &&
-    !array_key_exists($activityTypeId, $activityTypes)
-  ) {
+  elseif ($activityTypeId && !array_key_exists($activityTypeId, $activityTypes)) {
     throw new API_Exception('Invalid Activity Type ID');
   }
 
@@ -415,7 +428,6 @@ SELECT  count(*)
   if (isset($params['duration_minutes']) && !is_numeric($params['duration_minutes'])) {
     throw new API_Exception('Invalid Activity Duration (in minutes)');
   }
-
 
   //if adding a new activity & date_time not set make it now
   // this should be managed by the wrapper layer & setting ['api.default'] in speces
@@ -428,7 +440,7 @@ SELECT  count(*)
 }
 
 /**
- * @see _civicrm_api3_generic_getlist_params.
+ * @see _civicrm_api3_generic_getlist_params
  *
  * @param $request array
  */
@@ -452,6 +464,7 @@ function _civicrm_api3_task_getlist_params(&$request) {
  */
 function _civicrm_api3_task_getlist_output($result, $request) {
   $output = array();
+
   if (!empty($result['values'])) {
     foreach ($result['values'] as $row) {
       $data = array(
@@ -459,25 +472,28 @@ function _civicrm_api3_task_getlist_output($result, $request) {
         'label' => $row[$request['label_field']] ? $row[$request['label_field']] : ts('(no subject)'),
         'description' => array(CRM_Core_Pseudoconstant::getLabel('CRM_Activity_BAO_Activity', 'activity_type_id', $row['activity_type_id'])),
       );
+
       if (!empty($row['activity_date_time'])) {
         $data['description'][0] .= ': ' . CRM_Utils_Date::customFormat($row['activity_date_time']);
       }
+
       if (!empty($row['source_contact_id'])) {
         $data['description'][] = ts('By %1', array(1 => CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $row['source_contact_id'], 'display_name')));
       }
+
       foreach ($request['extra'] as $field) {
         $data['extra'][$field] = isset($row[$field]) ? $row[$field] : NULL;
       }
+
       $output[] = $data;
     }
   }
+
   return $output;
 }
 
 function civicrm_api3_task_get($params) {
-
   $activityIds = [];
-
   $assigneeContactIds = CRM_Utils_Array::value('assignee_contact_id', $params);
   $assigneeContactIds = (array) $assigneeContactIds;
   $sourceContactIds = CRM_Utils_Array::value('source_contact_id', $params);
@@ -534,7 +550,7 @@ function civicrm_api3_task_get($params) {
           1 => [$value['id'], 'Integer'],
         ];
         $caseActivityResult = CRM_Core_DAO::executeQuery($caseActivityQuery, $caseActivityParams);
-        $getResult['values'][$key]['case_id'] = null;
+        $getResult['values'][$key]['case_id'] = NULL;
 
         if ($caseActivityResult->fetch()) {
           $getResult['values'][$key]['case_id'] = $caseActivityResult->case_id;
@@ -570,6 +586,7 @@ function _loadActivityIDsForContactIntoArray(
     'record_type_id' => $recordTypeId,
     'options' => ['limit' => 0],
   ]);
+
   foreach ($result['values'] as $value) {
     $activityIds[] = $value['activity_id'];
   }
@@ -610,57 +627,56 @@ function civicrm_api3_task_getoptions($params) {
 }
 
 function civicrm_api3_task_getstatuses($params) {
+  $optionGroupID = (int) CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'activity_status', 'id', 'name');
 
-    $optionGroupID = (int)CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'activity_status', 'id', 'name');
+  if ($optionGroupID) {
+    return $result = civicrm_api3('OptionValue', 'get', array_merge($params, array(
+      'option_group_id' => $optionGroupID,
+    )));
+  }
 
-    if ($optionGroupID) {
-        return $result = civicrm_api3('OptionValue', 'get', array_merge($params, array(
-          'option_group_id' => $optionGroupID,
-        )));
-    }
-
-    return null;
+  return NULL;
 }
 
-/*
+/**
  * Task Reminder on demand.
  */
 function civicrm_api3_task_sendreminder($params) {
+  if (empty($params['activity_id'])) {
+    throw new API_Exception(ts("Please specify 'activity_id' value."));
+  }
 
-    if (empty($params['activity_id'])) {
-        throw new API_Exception(ts("Please specify 'activity_id' value."));
-    }
+  $result = CRM_Tasksassignments_Reminder::sendReminder((int) $params['activity_id'],
+    isset($params['notes']) ? $params['notes'] : '', TRUE);
 
-    $result = CRM_Tasksassignments_Reminder::sendReminder((int)$params['activity_id'], isset($params['notes']) ? $params['notes'] : '', true);
-    return civicrm_api3_create_success($result, $params, 'task', 'reminder');
+  return civicrm_api3_create_success($result, $params, 'task', 'reminder');
 }
 
-/*
+/**
  * Daily Task Reminder.
  */
 function civicrm_api3_task_senddailyreminder($params) {
-
-    CRM_Tasksassignments_Reminder::sendDailyReminder();
-    return civicrm_api3_create_success(1, $params, 'task', 'dailyreminder');
+  CRM_Tasksassignments_Reminder::sendDailyReminder();
+  return civicrm_api3_create_success(1, $params, 'task', 'dailyreminder');
 }
 
 function civicrm_api3_task_getcontactlist($params) {
   $options = array();
   $sortName = isset($params['sort_name']) ? $params['sort_name'] : '';
-  $relationshipName = isset($params['relationship_name']) ? $params['relationship_name'] : null;
-  $relatedContactId = isset($params['related_contact_id']) ? $params['related_contact_id'] : null;
-  $includeRelatedContact = isset($params['include_related_contact']) ? $params['include_related_contact'] : false;
+  $relationshipName = isset($params['relationship_name']) ? $params['relationship_name'] : NULL;
+  $relatedContactId = isset($params['related_contact_id']) ? $params['related_contact_id'] : NULL;
+  $includeRelatedContact = isset($params['include_related_contact']) ? $params['include_related_contact'] : FALSE;
   $params = array(
     "contact_is_deleted" => 0,
     "sort_name" => $sortName,
     "options" => array(
-        "limit" => 0,
-        "offset" => 0,
-        "sort" => "sort_name",
+      "limit" => 0,
+      "offset" => 0,
+      "sort" => "sort_name",
     ),
     "sequential" => 1,
     "return" => array("email", "sort_name", "contact_type"),
-    "check_permissions" => false,
+    "check_permissions" => FALSE,
     "version" => 3,
   );
 
@@ -670,35 +686,41 @@ function civicrm_api3_task_getcontactlist($params) {
       'name_a_b' => $relationshipName,
     ));
     $relationshipType = CRM_Utils_Array::first($relationshipTypeResult['values']);
+
     if ($relationshipType['id']) {
       $relationshipResult = civicrm_api3('Relationship', 'get', array(
         'sequential' => 1,
-        'relationship_type_id' => (int)$relationshipType['id'],
+        'relationship_type_id' => (int) $relationshipType['id'],
         'contact_id_b' => $relatedContactId,
         'return' => "contact_id_a",
       ));
       $relationshipContactIds = array();
+
       foreach ($relationshipResult['values'] as $relationship) {
-        $relationshipContactIds[] = (int)$relationship['contact_id_a'];
+        $relationshipContactIds[] = (int) $relationship['contact_id_a'];
       }
+
       if ($includeRelatedContact) {
         $relationshipContactIds[] = $relatedContactId;
       }
+
       if (empty($relationshipContactIds)) {
         return civicrm_api3_create_success(array(), $params, 'contact');
       }
+
       $params['id'] = array('IN' => $relationshipContactIds);
     }
   }
 
   _civicrm_api3_task_get_supportanomalies($params, $options);
   $contacts = _civicrm_api3_get_using_query_object('contact', $params, $options);
+
   return civicrm_api3_create_success($contacts, $params, 'contact');
 }
 
 function civicrm_api3_task_getcontact($params) {
-    $params['check_permissions'] = false;
-    return civicrm_api3('Contact', 'get', $params);
+  $params['check_permissions'] = FALSE;
+  return civicrm_api3('Contact', 'get', $params);
 }
 
 function _civicrm_api3_task_get_supportanomalies(&$params, &$options) {
@@ -706,24 +728,31 @@ function _civicrm_api3_task_get_supportanomalies(&$params, &$options) {
     if (strtolower($params['showAll']) == "active") {
       $params['contact_is_deleted'] = 0;
     }
+
     if (strtolower($params['showAll']) == "trash") {
       $params['contact_is_deleted'] = 1;
     }
+
     if (strtolower($params['showAll']) == "all" && isset($params['contact_is_deleted'])) {
       unset($params['contact_is_deleted']);
     }
   }
+
   // support for group filters
   if (array_key_exists('filter_group_id', $params)) {
     $params['filter.group_id'] = $params['filter_group_id'];
     unset($params['filter_group_id']);
   }
+
   // filter.group_id works both for 1,2,3 and array (1,2,3)
   if (array_key_exists('filter.group_id', $params)) {
     if (is_array($params['filter.group_id'])) {
       $groups = $params['filter.group_id'];
     }
-    else $groups = explode(',', $params['filter.group_id']);
+    else {
+      $groups = explode(',', $params['filter.group_id']);
+    }
+
     unset($params['filter.group_id']);
     $groups = array_flip($groups);
     $groups[key($groups)] = 1;

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/Task.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/Task.php
@@ -504,15 +504,6 @@ function civicrm_api3_task_get($params) {
     return civicrm_api3_create_success([], $params, 'task', 'getbycomponent');
   }
 
-  if ($caseId) {
-    $activities = CRM_Case_BAO_Case::getCaseActivity($caseId);
-    $caseActivityIds = array_column($activities['data'], 'DT_RowId');
-    $activityIds = !empty($activityIds) ? array_intersect($activityIds, $caseActivityIds) : $caseActivityIds;
-    if (empty($activityIds)) {
-      $activityIds[] = 0;
-    }
-  }
-
   if (!isset($params['id']) && !empty($activityIds)) {
     $params['id'] = array('IN' => $activityIds);
   }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
@@ -13,11 +13,11 @@ use CRM_Tasksassignments_Test_Fabricator_OptionValue as OptionValueFabricator;
 class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
   const SAMPLE_TASKS_COUNT = 3;
 
-  private $_case = null;
-  private $_taskType = null;
+  private $_case = NULL;
+  private $_taskType = NULL;
   private $_tasks = [];
 
-  function setUp() {
+  public function setUp() {
     parent::setUp();
     $upgrader = CRM_Tasksassignments_Upgrader::instance();
     $upgrader->install();
@@ -58,7 +58,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
   /**
    * @expectedException CRM_Exception
    */
-  function testCreateTaskWithNoContacts() {
+  public function testCreateTaskWithNoContacts() {
     $params = array(
       'activity_type_id' => $this->_taskType['value'],
     );
@@ -68,7 +68,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
   /**
    * @expectedException CRM_Exception
    */
-  function testCreateTaskWithNoSource() {
+  public function testCreateTaskWithNoSource() {
     $params = array(
       'activity_type_id' => $this->_taskType['value'],
       'assignee_contact_id' => 1,
@@ -77,7 +77,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
     CRM_Tasksassignments_BAO_Task::create($params);
   }
 
-  function testCreateTaskWithNoAssignee() {
+  public function testCreateTaskWithNoAssignee() {
     $params = array(
       'activity_type_id' => $this->_taskType['value'],
       'source_contact_id' => 1,
@@ -92,7 +92,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
   /**
    * @expectedException CRM_Exception
    */
-  function testCreateTaskWithNoTarget() {
+  public function testCreateTaskWithNoTarget() {
     $params = array(
       'activity_type_id' => $this->_taskType['value'],
       'source_contact_id' => 1,
@@ -101,7 +101,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
     CRM_Tasksassignments_BAO_Task::create($params);
   }
 
-  function testClosingTheCaseWhenAllTasksAreCompleted() {
+  public function testClosingTheCaseWhenAllTasksAreCompleted() {
     $this->setupCaseAndTasks();
 
     foreach ($this->_tasks as $task) {
@@ -119,7 +119,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
     $this->assertEquals('Closed', $updatedCase['status_id.name']);
   }
 
-  function testNotClosingTheCaseWhenOnlySomeTasksAreCompleted() {
+  public function testNotClosingTheCaseWhenOnlySomeTasksAreCompleted() {
     $this->setupCaseAndTasks();
 
     civicrm_api3('Task', 'create', [
@@ -135,7 +135,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
     $this->assertEquals('Open', $updatedCase['status_id.name']);
   }
 
-  function testNotClosingTHeCaseWhenTheCaseCategoryIsNotWorkflow() {
+  public function testNotClosingTHeCaseWhenTheCaseCategoryIsNotWorkflow() {
     $vacancyType = CaseTypeFabricator::fabricate([
       'name' => 'Application',
       'category' => 'VACANCY'
@@ -159,4 +159,5 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
 
     $this->assertEquals('Open', $updatedCase['status_id.name']);
   }
+
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
@@ -112,4 +112,20 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
 
     $this->assertEquals('Closed', $updatedCase['status_id.name']);
   }
+
+  function testNotClosingTheCaseWhenOnlySomeTasksAreCompleted() {
+    $this->setupCaseAndTasks();
+
+    civicrm_api3('Task', 'create', [
+      'id' => $this->_tasks[0]['id'],
+      'status_id' => 'Completed'
+    ]);
+
+    $updatedCase = civicrm_api3('Case', 'getsingle', [
+      'id' => $this->_case['id'],
+      'return' => [ 'status_id.name' ]
+    ]);
+
+    $this->assertEquals('Open', $updatedCase['status_id.name']);
+  }
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
@@ -38,8 +38,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
     $defaultCaseParameters = [
       'contact_id' => $contact['id'],
       'creator_id' => $contact['id'],
-      'case_type_id' => $caseType['id'],
-      'subject' => 'Sample Case'
+      'case_type_id' => $caseType['id']
     ];
     $caseParameters = array_merge($defaultCaseParameters, $caseParameters);
     $this->_case = CaseFabricator::fabricate($caseParameters);

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
@@ -6,6 +6,7 @@ use CRM_Tasksassignments_Test_Fabricator_CaseType as CaseTypeFabricator;
 use CRM_Tasksassignments_Test_Fabricator_Contact as ContactFabricator;
 use CRM_Tasksassignments_Test_Fabricator_Task as TaskFabricator;
 use CRM_Tasksassignments_Test_Fabricator_OptionValue as OptionValueFabricator;
+use CRM_Tasksassignments_Test_Fabricator_OptionGroup as OptionGroupFabricator;
 
 /**
  * @group headless
@@ -24,9 +25,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
 
     $this->_taskType = OptionValueFabricator::fabricateTaskType();
 
-    civicrm_api3('OptionGroup', 'create', ['name' => 'case_type_category']);
-    OptionValueFabricator::fabricate([ 'name' => 'WORKFLOW', 'option_group_id' => 'case_type_category' ]);
-    OptionValueFabricator::fabricate([ 'name' => 'VACANCY', 'option_group_id' => 'case_type_category'  ]);
+    OptionGroupFabricator::fabricateCaseCategoryGroupAndValues();
   }
 
   /**

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/CRM/Tasksassignments/BAO/TaskTest.php
@@ -1,23 +1,52 @@
 <?php
 
 use CRM_Tasksassignments_Test_BaseHeadlessTest as BaseHeadlessTest;
+use CRM_Tasksassignments_Test_Fabricator_Case as CaseFabricator;
+use CRM_Tasksassignments_Test_Fabricator_CaseType as CaseTypeFabricator;
+use CRM_Tasksassignments_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Tasksassignments_Test_Fabricator_Task as TaskFabricator;
+use CRM_Tasksassignments_Test_Fabricator_OptionValue as OptionValueFabricator;
 
 /**
  * @group headless
  */
 class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
-  private $_taskTypeId = null;
+  const SAMPLE_TASKS_COUNT = 3;
+
+  private $_case = null;
+  private $_taskType = null;
+  private $_tasks = [];
 
   function setUp() {
     parent::setUp();
     $upgrader = CRM_Tasksassignments_Upgrader::instance();
     $upgrader->install();
 
-    // Pick one of Task types.
-    $taskTypes = civicrm_api3('Task', 'getoptions', array(
-      'field' => 'activity_type_id',
-    ));
-    $this->_taskTypeId = array_shift($taskTypes['values']);
+    $this->_taskType = OptionValueFabricator::fabricateTaskType();
+  }
+
+  /**
+   * Fabricates and stores a Case and a list of Tasks for testing purposes.
+   */
+  private function setupCaseAndTasks() {
+    $contact = ContactFabricator::fabricate();
+    $caseType = CaseTypeFabricator::fabricate();
+    $this->_case = CaseFabricator::fabricate([
+      'contact_id' => $contact['id'],
+      'creator_id' => $contact['id'],
+      'case_type_id' => $caseType['id'],
+      'subject' => 'Sample Case'
+    ]);
+
+    for ($i = 0; $i < self::SAMPLE_TASKS_COUNT; $i++) {
+      $this->_tasks[] = TaskFabricator::fabricate([
+        'case_id' => $this->_case['id'],
+        'source_contact_id' => $contact['id'],
+        'target_contact_id' => $contact['id'],
+        'activity_type_id' => $this->_taskType['value'],
+        'status_id' => 'Scheduled'
+      ]);
+    }
   }
 
   /**
@@ -25,7 +54,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
    */
   function testCreateTaskWithNoContacts() {
     $params = array(
-      'activity_type_id' => $this->_taskTypeId,
+      'activity_type_id' => $this->_taskType['value'],
     );
     CRM_Tasksassignments_BAO_Task::create($params);
   }
@@ -35,7 +64,7 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
    */
   function testCreateTaskWithNoSource() {
     $params = array(
-      'activity_type_id' => $this->_taskTypeId,
+      'activity_type_id' => $this->_taskType['value'],
       'assignee_contact_id' => 1,
       'target_contact_id' => 2,
     );
@@ -44,14 +73,14 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
 
   function testCreateTaskWithNoAssignee() {
     $params = array(
-      'activity_type_id' => $this->_taskTypeId,
+      'activity_type_id' => $this->_taskType['value'],
       'source_contact_id' => 1,
       'target_contact_id' => 2,
     );
     $result = CRM_Tasksassignments_BAO_Task::create($params);
 
     $this->assertTrue($result instanceof CRM_Activity_DAO_Activity);
-    $this->assertEquals($this->_taskTypeId, $result->activity_type_id);
+    $this->assertEquals($this->_taskType['value'], $result->activity_type_id);
   }
 
   /**
@@ -59,10 +88,28 @@ class CRM_Tasksassignments_BAO_TaskTest extends BaseHeadlessTest {
    */
   function testCreateTaskWithNoTarget() {
     $params = array(
-      'activity_type_id' => $this->_taskTypeId,
+      'activity_type_id' => $this->_taskType['value'],
       'source_contact_id' => 1,
       'assignee_contact_id' => 2,
     );
     CRM_Tasksassignments_BAO_Task::create($params);
+  }
+
+  function testClosingTheCaseWhenAllTasksAreCompleted() {
+    $this->setupCaseAndTasks();
+
+    foreach ($this->_tasks as $task) {
+      civicrm_api3('Task', 'create', [
+        'id' => $task['id'],
+        'status_id' => 'Completed'
+      ]);
+    }
+
+    $updatedCase = civicrm_api3('Case', 'getsingle', [
+      'id' => $this->_case['id'],
+      'return' => [ 'status_id.name' ]
+    ]);
+
+    $this->assertEquals('Closed', $updatedCase['status_id.name']);
   }
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
@@ -185,8 +185,7 @@ class api_v3_TaskTest extends BaseHeadlessTest {
     $case = CaseFabricator::fabricate([
       'contact_id' => $cecil['id'],
       'creator_id' => $cecil['id'],
-      'case_type_id' => $caseType['id'],
-      'subject' => 'Sample Joining Case'
+      'case_type_id' => $caseType['id']
     ]);
 
     $tasksAssignedToAna = $this->fabricateSeveralTasks(6, [

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TaskTest.php
@@ -6,6 +6,7 @@ use CRM_Tasksassignments_Test_Fabricator_Case as CaseFabricator;
 use CRM_Tasksassignments_Test_Fabricator_CaseType as CaseTypeFabricator;
 use CRM_Tasksassignments_Test_Fabricator_Task as TaskFabricator;
 use CRM_Tasksassignments_Test_Fabricator_Contact as ContactFabricator;
+use CRM_Tasksassignments_Test_Fabricator_OptionGroup as OptionGroupFabricator;
 
 /**
  * @group headless
@@ -28,9 +29,7 @@ class api_v3_TaskTest extends BaseHeadlessTest {
 
     $this->_taskTypeId = $result['value'];
 
-    civicrm_api3('OptionGroup', 'create', ['name' => 'case_type_category']);
-    OptionValueFabricator::fabricate([ 'name' => 'WORKFLOW', 'option_group_id' => 'case_type_category' ]);
-    OptionValueFabricator::fabricate([ 'name' => 'VACANCY', 'option_group_id' => 'case_type_category'  ]);
+    OptionGroupFabricator::fabricateCaseCategoryGroupAndValues();
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR automatically closes cases when all of its child tasks have been completed successfully. This is only true for cases of the "Workflow" category (see [this PR](https://github.com/compucorp/civicrm-core/pull/15) for more information about workflow categories).

## Before
![anim](https://user-images.githubusercontent.com/1642119/38933688-b0a05220-42e7-11e8-85df-69e80455f9c4.gif)

## After
![anim](https://user-images.githubusercontent.com/1642119/38933395-c890d4fa-42e6-11e8-8031-4a54b0d73cd4.gif)

## Technical Details

A new check was added when updating tasks to determine if the parent case can be closed:

```php
public static function create(&$params) {
  // ...

  if ($hook === 'edit') {
    $isWorkflowCaseCategory = 'WORKFLOW' === self::getCaseCategory($instance->case_id);
    $allCaseTasksAreCompleted = self::checkIfTasksBelongingToCaseAreCompleted($instance->case_id);

    if ($isWorkflowCaseCategory && $allCaseTasksAreCompleted) {
      self::markCaseAsClosed($instance->case_id);
    }
  }
}

private static function getCaseCategory($caseId) {
  if (empty($caseId)) {
    return NULL;
  }

  $case = civicrm_api3('Case', 'getsingle', [
    'id' => $caseId,
    'return' => [ 'case_type_id.category.name' ]
  ]);

  return $case['case_type_id.category.name'];
}

private static function checkIfTasksBelongingToCaseAreCompleted($caseId) {
  if (empty($caseId)) {
    return FALSE;
  }

  $tasks = civicrm_api3('Task', 'get', [
    'case_id' => $caseId,
    'return' => ['status_id.name']
  ]);

  foreach ($tasks['values'] as $task) {
    if ($task['status_id.name'] !== self::COMPLETED_STATUS) {
      return FALSE;
    }
  }

  return TRUE;
}
```

* A new Case fabricator was added.
* Added missing sample data to the CaseType fabricator. Without this data the fabrication of case types fails:

```php
private static $defaultParams = [
  'title' => 'Test Case Type',
  'name' => 'test_case_type',
  'category' => 'WORKFLOW',
  'is_active' => 1,
  'sequential'   => 1,
  'weight' => 100,
  'definition' => [
    'activityTypes' => [
      ['name' => 'Test'],
    ],
    'activitySets' => [
      [
        'name' => 'set1',
        'label' => 'Label 1',
        'timeline' => 1,
        'activityTypes' => [
          ['name' => 'Open Case', 'status' => 'Completed'],
        ],
      ],
    ],
  ],
];
```
* There was an issue when merging the default parameters of a few of the fabricators, the default params should go first and the overriding params second:
```php
$params = array_merge(self::$defaultParams, $params);
```
* The retrieval of case's activities IDs was changed from:
```php
$caseActivityIds = array_keys(CRM_Case_BAO_Case::getCaseActivity($caseId));
```
To
```php
$activities = CRM_Case_BAO_Case::getCaseActivity($caseId);
$caseActivityIds = array_column($activities['data'], 'DT_RowId');
```

The `CRM_Case_BAO_Case::getCaseActivity` [was changed 3 years]() ago and it no longer returns an associative array of id/activity pairs, but an associative array with a sequential array of activities stored in the data property. More information can be found at the [source](https://github.com/compucorp/civicrm-core/blame/PCHR-3369-tasks-and-workflows-ux-improvements/CRM/Case/BAO/Case.php#L1229).


## Comments
These option group and values:
```php
civicrm_api3('OptionGroup', 'create', ['name' => 'case_type_category']);
OptionValueFabricator::fabricate([ 'name' => 'WORKFLOW', 'option_group_id' => 'case_type_category' ]);
OptionValueFabricator::fabricate([ 'name' => 'VACANCY', 'option_group_id' => 'case_type_category'  ]);
```

Were supposed to be added by a core upgrader, but for some reason they are not available on the test schema.

:warning: **Important**: This PR and tests fail because of the `case_id` filter:
https://github.com/compucorp/civihr-tasks-assignments/blob/f49ed71970e371689fe7204968ded5c1451cded1/uk.co.compucorp.civicrm.tasksassignments/api/v3/Task.php#L507-L514

This filter seems to have been added so tasks could be filtered by their `case_id` property, but the problem is that, among the many things that `CRM_Case_BAO_Case::getCaseActivity` does, one of them is to check if the CiviCase component is enabled:

https://github.com/compucorp/civicrm-core/blob/PCHR-3369-tasks-and-workflows-ux-improvements/CRM/Case/BAO/Case.php#L58-L61
```php
public static function enabled() {
  $config = CRM_Core_Config::singleton();
  return in_array('CiviCase', $config->enableComponents);
}
```

This returns an empty list of activities, and in turn this filter fails:

https://github.com/compucorp/civihr-tasks-assignments/blob/f49ed71970e371689fe7204968ded5c1451cded1/uk.co.compucorp.civicrm.tasksassignments/api/v3/Task.php#L517

I'm not sure why the `case_id` filter is important for the Task API file. In fact, removing the code for this filter and using the api as this:
```php
civicrm_api3(['Tasks', 'get', [ 'case_id' => 1 ]);
```
Works as it should. Can we delete this code safely? Does it have some other purpose other than filtering tasks by case?