### PR TITLE
PCHR-3418: Modify the "Add Activity" modal

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
@@ -75,6 +75,8 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
       $categoryOptions, FALSE
     );
 
+    Civi::resources()->addScriptFile('uk.co.compucorp.civicrm.tasksassignments', 'js/CRM/Form/Options.js');
+
     //$this->addFormRule(array('CRM_Admin_Form_Options', 'formRule'), $this);
   }
 

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
@@ -40,7 +40,7 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
    *
    * @return void
    */
-  function setDefaultValues() {
+  public function setDefaultValues() {
     $defaults = parent::setDefaultValues();
     return $defaults;
   }
@@ -53,33 +53,35 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
    */
   public function buildQuickForm() {
     parent::buildQuickForm();
-    
+
     $newOptions = array();
+
     if ($this->elementExists('component_id')) {
-        $componentSelectElement = $this->getElement('component_id');
-        $options = $componentSelectElement->_options;
-        foreach ($options as $value) {
-          $newOptions[$value['attr']['value']] = $value['text'];
-        }
+      $componentSelectElement = $this->getElement('component_id');
+      $options = $componentSelectElement->_options;
+
+      foreach ($options as $value) {
+        $newOptions[$value['attr']['value']] = $value['text'];
+      }
     }
-    
+
     $civiTaskId = CRM_Core_Component::getComponentID('CiviTask');
-    if ($civiTaskId !== null)
-    {
-        $newOptions[$civiTaskId] = t('Tasks and Assignments');
-    }
     $civiDocumentId = CRM_Core_Component::getComponentID('CiviDocument');
-    if ($civiDocumentId !== null)
-    {
-        $newOptions[$civiDocumentId] = t('Documents and Assignments');
+
+    if ($civiTaskId !== NULL) {
+      $newOptions[$civiTaskId] = t('Tasks and Assignments');
     }
-    
+
+    if ($civiDocumentId !== NULL) {
+      $newOptions[$civiDocumentId] = t('Documents and Assignments');
+    }
+
     $this->add('select',
       'component_id',
       ts('Component'),
       $newOptions, FALSE
     );
-    
+
     //$this->addFormRule(array('CRM_Admin_Form_Options', 'formRule'), $this);
   }
 
@@ -94,7 +96,7 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
    * @access public
    * @static
    */
-  static function formRule($fields, $files, $self) {
+  public static function formRule($fields, $files, $self) {
     return parent::formRule($fields, $files, $self);
   }
 
@@ -108,4 +110,5 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
   public function postProcess() {
     return parent::postProcess();
   }
+
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
@@ -56,32 +56,23 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
 
     CRM_Utils_System::setTitle('Add New Task / Document Type');
 
-    $newOptions = array();
-
-    if ($this->elementExists('component_id')) {
-      $componentSelectElement = $this->getElement('component_id');
-      $options = $componentSelectElement->_options;
-
-      foreach ($options as $value) {
-        $newOptions[$value['attr']['value']] = $value['text'];
-      }
-    }
+    $categoryOptions = array();
 
     $civiTaskId = CRM_Core_Component::getComponentID('CiviTask');
     $civiDocumentId = CRM_Core_Component::getComponentID('CiviDocument');
 
     if ($civiTaskId !== NULL) {
-      $newOptions[$civiTaskId] = t('Tasks');
+      $categoryOptions[$civiTaskId] = t('Tasks');
     }
 
     if ($civiDocumentId !== NULL) {
-      $newOptions[$civiDocumentId] = t('Documents');
+      $categoryOptions[$civiDocumentId] = t('Documents');
     }
 
     $this->add('select',
       'component_id',
       ts('Category'),
-      $newOptions, FALSE
+      $categoryOptions, FALSE
     );
 
     //$this->addFormRule(array('CRM_Admin_Form_Options', 'formRule'), $this);

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
@@ -56,7 +56,7 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
 
     CRM_Utils_System::setTitle('Add New Task / Document Type');
 
-    $categoryOptions = array();
+    $categoryOptions = [];
 
     $civiTaskId = CRM_Core_Component::getComponentID('CiviTask');
     $civiDocumentId = CRM_Core_Component::getComponentID('CiviDocument');
@@ -76,8 +76,6 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
     );
 
     Civi::resources()->addScriptFile('uk.co.compucorp.civicrm.tasksassignments', 'js/CRM/Form/Options.js');
-
-    //$this->addFormRule(array('CRM_Admin_Form_Options', 'formRule'), $this);
   }
 
   /**

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
@@ -54,6 +54,8 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
   public function buildQuickForm() {
     parent::buildQuickForm();
 
+    CRM_Utils_System::setTitle('Add New Task / Document Type');
+
     $newOptions = array();
 
     if ($this->elementExists('component_id')) {
@@ -69,16 +71,16 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
     $civiDocumentId = CRM_Core_Component::getComponentID('CiviDocument');
 
     if ($civiTaskId !== NULL) {
-      $newOptions[$civiTaskId] = t('Tasks and Assignments');
+      $newOptions[$civiTaskId] = t('Tasks');
     }
 
     if ($civiDocumentId !== NULL) {
-      $newOptions[$civiDocumentId] = t('Documents and Assignments');
+      $newOptions[$civiDocumentId] = t('Documents');
     }
 
     $this->add('select',
       'component_id',
-      ts('Component'),
+      ts('Category'),
       $newOptions, FALSE
     );
 

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Form/Options.php
@@ -54,7 +54,14 @@ class CRM_Tasksassignments_Form_Options extends CRM_Admin_Form_Options {
   public function buildQuickForm() {
     parent::buildQuickForm();
 
-    CRM_Utils_System::setTitle('Add New Task / Document Type');
+    $isNewOptionValue = empty($this->get('id'));
+
+    if ($isNewOptionValue) {
+      CRM_Utils_System::setTitle('Add New Task / Document Type');
+    }
+    else {
+      CRM_Utils_System::setTitle('Edit Task / Document Type');
+    }
 
     $categoryOptions = [];
 

--- a/uk.co.compucorp.civicrm.tasksassignments/js/CRM/Form/Options.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/CRM/Form/Options.js
@@ -1,0 +1,9 @@
+'use strict';
+
+(function init () {
+  var componentIdRow = CRM.$('select#component_id').parents('tr');
+  var tableBody = componentIdRow.parents('tbody');
+
+  // Move the category field to the top of the form:
+  componentIdRow.detach().prependTo(tableBody);
+})();

--- a/uk.co.compucorp.civicrm.tasksassignments/js/CRM/Form/Options.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/CRM/Form/Options.js
@@ -1,9 +1,9 @@
 'use strict';
 
-(function init () {
-  var componentIdRow = CRM.$('select#component_id').parents('tr');
-  var tableBody = componentIdRow.parents('tbody');
+(function init (CRM) {
+  var componentIdRow = CRM.$('#component_id').closest('tr');
+  var tableBody = componentIdRow.closest('tbody');
 
   // Move the category field to the top of the form:
-  componentIdRow.detach().prependTo(tableBody);
-})();
+  componentIdRow.prependTo(tableBody);
+})(CRM);


### PR DESCRIPTION
## Overview
This PR makes the following changes to the "Add Activity" modal on the activity types configuration screen:

* It renames the modal title to "Add New Task / Document Type".
* It renames the "Component" field to "Category".
* It only displays "Tasks" and "Documents" in the "Category" options.
* It moves the "Category" field to the top of the form

## Before
![activity-before](https://user-images.githubusercontent.com/1642119/39623470-b7642fa4-4f63-11e8-8908-fec57151b51a.png)

## After
![activity-after](https://user-images.githubusercontent.com/1642119/39622875-c5a9e434-4f61-11e8-86e3-4a65a3c79487.png)

## Technical Details
The code that makes all the changes reads as follows:
```php
public function buildQuickForm() {
  parent::buildQuickForm();

  // Changes the title of the modal:
  CRM_Utils_System::setTitle('Add New Task / Document Type');

  // Adds the "Tasks" and "Documents" options to the "Category" dropdown:
  $categoryOptions = array();

  $civiTaskId = CRM_Core_Component::getComponentID('CiviTask');
  $civiDocumentId = CRM_Core_Component::getComponentID('CiviDocument');

  if ($civiTaskId !== NULL) {
    $categoryOptions[$civiTaskId] = t('Tasks');
  }

  if ($civiDocumentId !== NULL) {
    $categoryOptions[$civiDocumentId] = t('Documents');
  }

  $this->add('select',
    'component_id',
    ts('Category'),
    $categoryOptions, FALSE
  );

  // ...
}
```

The following code was removed since it was leaving category options for other components that are not relevant to Tasks and Workflows:

```php
// removed this:
$newOptions = array();
if ($this->elementExists('component_id')) {
  $componentSelectElement = $this->getElement('component_id');
  $options = $componentSelectElement->_options;

  foreach ($options as $value) {
    $newOptions[$value['attr']['value']] = $value['text'];
  }
}
```

To change the order of the category field a JS file was injected into the form template:

```php
    Civi::resources()->addScriptFile('uk.co.compucorp.civicrm.tasksassignments', 'js/CRM/Form/Options.js');
```

```js
'use strict';

(function init () {
  var componentIdRow = CRM.$('select#component_id').parents('tr');
  var tableBody = componentIdRow.parents('tbody');

  // Move the category field to the top of the form:
  componentIdRow.detach().prependTo(tableBody);
})();
```

This approach was chosen because the core form template specifies each individual field manually. For example:
https://github.com/civicrm/civicrm-core/blob/3d04355de56e2293afda299bc4e00d5816010082/templates/CRM/Admin/Form/Options.tpl#L58-L63

This makes the whole form hard to extend and using Javascript to move the field is the easiest solution and more future proof.

