### PR TITLE
PCHR-3700: Add Activity Type menu item

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -895,6 +895,24 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Adds a new menu item for Activity Types under the tasks administration menu.
+   *
+   * @return bool
+   */
+  public function upgrade_1037() {
+    civicrm_api3('Navigation', 'create', [
+      'label' => 'Activity Types',
+      'name' => 'activity_types_administer',
+      'url' => 'civicrm/admin/options/activity_type?reset=1',
+      'permission' => 'administer CiviCase',
+      'parent_id' => 'tasksassignments_administer',
+      'is_active' => 1,
+    ]);
+
+    return TRUE;
+  }
+
   public function uninstall() {
     CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard_tasks', 'ta_dashboard_documents', 'ta_dashboard_calendar', 'ta_dashboard_keydates', 'tasksassignments_administer', 'ta_settings')");
     CRM_Core_BAO_Navigation::resetNavigation();

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -901,14 +901,21 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1037() {
-    civicrm_api3('Navigation', 'create', [
-      'label' => 'Activity Types',
+    $activityTypeMenuItem = civicrm_api3('Navigation', 'get', [
       'name' => 'activity_types_administer',
-      'url' => 'civicrm/admin/options/activity_type?reset=1',
-      'permission' => 'administer CiviCase',
-      'parent_id' => 'tasksassignments_administer',
-      'is_active' => 1,
     ]);
+
+    // Create the menu item only if it doesn't exist:
+    if ($activityTypeMenuItem['count'] === 0) {
+      civicrm_api3('Navigation', 'create', [
+        'label' => 'Activity Types',
+        'name' => 'activity_types_administer',
+        'url' => 'civicrm/admin/options/activity_type?reset=1',
+        'permission' => 'administer CiviCase',
+        'parent_id' => 'tasksassignments_administer',
+        'is_active' => 1,
+      ]);
+    }
 
     return TRUE;
   }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -908,7 +908,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
     // Create the menu item only if it doesn't exist:
     if ($activityTypeMenuItem['count'] === 0) {
       civicrm_api3('Navigation', 'create', [
-        'label' => 'Activity Types',
+        'label' => 'Task and Document Types',
         'name' => 'activity_types_administer',
         'url' => 'civicrm/admin/options/activity_type?reset=1',
         'permission' => 'administer CiviCase',

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -902,14 +902,14 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
    */
   public function upgrade_1037() {
     $activityTypeMenuItem = civicrm_api3('Navigation', 'get', [
-      'name' => 'activity_types_administer',
+      'name' => 'task_and_document_types_administer',
     ]);
 
     // Create the menu item only if it doesn't exist:
     if ($activityTypeMenuItem['count'] === 0) {
       civicrm_api3('Navigation', 'create', [
         'label' => 'Task and Document Types',
-        'name' => 'activity_types_administer',
+        'name' => 'task_and_document_types_administer',
         'url' => 'civicrm/admin/options/activity_type?reset=1',
         'permission' => 'administer CiviCase',
         'parent_id' => 'tasksassignments_administer',


### PR DESCRIPTION
## Overview
This PR adds a new menu item for Activity Types under the tasks administration menu. 

## Before
![before-menu-item](https://user-images.githubusercontent.com/1642119/40231830-8abe7cae-5a6a-11e8-8808-fdd60e3d5d32.png)

## After
![after-menu-item](https://user-images.githubusercontent.com/1642119/40231832-8cc95898-5a6a-11e8-9184-4e3a85ad63da.png)


## Technical Details

A new upgrader was added:

```php
public function upgrade_1037() {
  civicrm_api3('Navigation', 'create', [
    'label' => 'Activity Types',
    'name' => 'activity_types_administer',
    'url' => 'civicrm/admin/options/activity_type?reset=1',
    'permission' => 'administer CiviCase',
    'parent_id' => 'tasksassignments_administer',
    'is_active' => 1,
  ]);

  return TRUE;
}
```

## Comments
This task is about adding a new menu item, not replacing/moving the old one under `Configure > Customize Data and Screens > Activity Type`
