### PR TITLE
PCHR-3769: Fix build process

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/gulpfile.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/gulpfile.js
@@ -34,12 +34,21 @@ gulp.task('crm-js-bundle', function () {
     .pipe(gulp.dest('js/dist/'));
 });
 
-gulp.task('requirejs-bundle', function (done) {
-  exec('r.js -o js/build.js', function (err, stdout, stderr) {
+gulp.task('requirejs-bundle-ta', function (done) {
+  exec('r.js -o js/tasks-assignments.build.js', function (err, stdout, stderr) {
     err && err.code && console.log(stdout);
     done();
   });
 });
+
+gulp.task('requirejs-bundle-badge', function (done) {
+  exec('r.js -o js/tasks-notification-badge.build.js', function (err, stdout, stderr) {
+    err && err.code && console.log(stdout);
+    done();
+  });
+});
+
+gulp.task('requirejs-bundle', ['requirejs-bundle-ta', 'requirejs-bundle-badge']);
 
 gulp.task('watch', function () {
   gulp.watch('scss/**/*.scss', ['sass']);

--- a/uk.co.compucorp.civicrm.tasksassignments/gulpfile.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task('sass', function (done) {
   });
 });
 
-gulp.task('crm-js-bundle', function () {
+gulp.task('js-bundle:crm', function () {
   return gulp.src([
     'js/src/crm-tasks-workflows/modules/*.js',
     'js/src/crm-tasks-workflows/controllers/*.js',
@@ -34,21 +34,19 @@ gulp.task('crm-js-bundle', function () {
     .pipe(gulp.dest('js/dist/'));
 });
 
-gulp.task('requirejs-bundle-ta', function (done) {
+gulp.task('js-bundle:requirejs:ta', function (done) {
   exec('r.js -o js/tasks-assignments.build.js', function (err, stdout, stderr) {
     err && err.code && console.log(stdout);
     done();
   });
 });
 
-gulp.task('requirejs-bundle-badge', function (done) {
+gulp.task('js-bundle:requirejs:badge', function (done) {
   exec('r.js -o js/tasks-notification-badge.build.js', function (err, stdout, stderr) {
     err && err.code && console.log(stdout);
     done();
   });
 });
-
-gulp.task('requirejs-bundle', ['requirejs-bundle-ta', 'requirejs-bundle-badge']);
 
 gulp.task('watch', function () {
   gulp.watch('scss/**/*.scss', ['sass']);
@@ -57,13 +55,13 @@ gulp.task('watch', function () {
     'js/src/tasks-assignments/**/*.js',
     'js/src/tasks-notification-badge.js',
     'js/src/tasks-notification-badge/**/*.js'
-  ], ['requirejs-bundle']).on('change', function (file) {
+  ], ['js-bundle:requirejs']).on('change', function (file) {
     try { test.for(file.path); } catch (ex) { test.all(); }
   });
   gulp.watch([
     'js/src/crm-tasks-workflows.js',
     'js/src/crm-tasks-workflows/**/*.js'
-  ], ['crm-js-bundle']).on('change', function (file) {
+  ], ['js-bundle:crm']).on('change', function (file) {
     try { test.for(file.path); } catch (ex) { test.all(); }
   });
   gulp.watch([
@@ -91,7 +89,9 @@ gulp.task('test', function (done) {
   test.all();
 });
 
-gulp.task('default', ['crm-js-bundle', 'requirejs-bundle', 'sass', 'test', 'watch']);
+gulp.task('js-bundle:requirejs', ['js-bundle:requirejs:ta', 'js-bundle:requirejs:badge']);
+gulp.task('js-bundle', ['js-bundle:crm', 'js-bundle:requirejs']);
+gulp.task('default', ['js-bundle', 'sass', 'test', 'watch']);
 
 var test = (function () {
   /**

--- a/uk.co.compucorp.civicrm.tasksassignments/js/tasks-assignments.build.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/tasks-assignments.build.js
@@ -11,12 +11,4 @@
     'tasks-assignments/vendor/angular-checklist-model': 'tasks-assignments/vendor/angular/checklist-model',
     'tasks-assignments/vendor/angular-router': 'tasks-assignments/vendor/angular/angular-ui-router',
   }
-},{
-  baseUrl : 'src',
-  out: 'dist/tasks-notification-badge.min.js',
-  name: 'tasks-notification-badge',
-  skipModuleInsertion: true,
-  paths: {
-    'common': 'empty:'
-  }
 })

--- a/uk.co.compucorp.civicrm.tasksassignments/js/tasks-notification-badge.build.js
+++ b/uk.co.compucorp.civicrm.tasksassignments/js/tasks-notification-badge.build.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+
+({
+  baseUrl : 'src',
+  out: 'dist/tasks-notification-badge.min.js',
+  name: 'tasks-notification-badge',
+  skipModuleInsertion: true,
+  paths: {
+    'common': 'empty:'
+  }
+})


### PR DESCRIPTION
## Overview
This PR https://github.com/compucorp/civihr-tasks-assignments/pull/363 introduced an error in the `build.js` file that resulted in the `tasks-assignments.min.js` file not being generated by the build process anymore.

## Problem
The problem was that a `build.js` file cannot contain multiple configuration objects, as the RequireJS optimizer will only read and use the last object it finds in the file

```js
({
  baseUrl : 'src',
  out: 'dist/tasks-assignments.min.js',
  name: 'tasks-assignments',
  skipModuleInsertion: true,
},{
  baseUrl : 'src',
  out: 'dist/tasks-notification-badge.min.js',
  name: 'tasks-notification-badge',
  skipModuleInsertion: true,
})
```
as a result, given that the configuration object for the `tasks-notification-badge` module was last, only that module was being built in the build process, while the `tasks-assignments` module was left ignored.

## Solution
A simple solution is to split `build.js` into two separate build files
```js
// tasks-assignments.build.js

({
  baseUrl : 'src',
  out: 'dist/tasks-assignments.min.js',
  name: 'tasks-assignments',
  skipModuleInsertion: true
})
```
```js
// tasks-notification-badge.build.js

({
  baseUrl : 'src',
  out: 'dist/tasks-notification-badge.min.js',
  name: 'tasks-notification-badge',
  skipModuleInsertion: true,
  paths: {
    'common': 'empty:'
  }
})
```
which are then handled separately by the build process
```js
// gulpfile.js

gulp.task('js-bundle:requirejs:ta', function (done) {
  exec('r.js -o js/tasks-assignments.build.js', function (err, stdout, stderr) {
    err && err.code && console.log(stdout);
    done();
  });
});

gulp.task('js-bundle:requirejs:badge', function (done) {
  exec('r.js -o js/tasks-notification-badge.build.js', function (err, stdout, stderr) {
    err && err.code && console.log(stdout);
    done();
  });
});

gulp.task('js-bundle:requirejs', ['js-bundle:requirejs:ta', 'js-bundle:requirejs:badge']);
```

## Technical Details
The js-related tasks have been re-arranged and renamed:

```js
gulp.task('js-bundle:crm', function () {});
gulp.task('js-bundle:requirejs:ta', function () {});
gulp.task('js-bundle:requirejs:badge', function () {});

gulp.task('js-bundle:requirejs', ['js-bundle:requirejs:ta', 'js-bundle:requirejs:badge']);
gulp.task('js-bundle', ['js-bundle:crm', 'js-bundle:requirejs']);
```