### PR TITLE
PCHR-3811: Update the civihr repo URL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -308,7 +308,7 @@ def mergeEnvBranchInAllRepositories(String envBranch) {
 def listRepositories() {
   return [
     [
-      'url': 'https://github.com/civicrm/civihr.git',
+      'url': 'https://github.com/compucorp/civihr.git',
       'folder': "$CIVICRM_EXT_ROOT/civihr"
     ],
     [


### PR DESCRIPTION
## Overview

The ownership of the civihr repository has been transferred from the CiviCRM organization to Compucorp. This PR updates references to the repo URL to reflect the new ownership.

## Before

URLs to the repository would reference `civicrm` as the owner.

## After

URLs to the repository now reference `compucorp` as the owner.