### PR TITLE
PCHR-3543: Update T&A Settings

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -928,10 +928,13 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
    */
   public function upgrade_1038() {
     $optionValue = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
       'option_group_id' => 'ta_settings',
       'name' => 'days_to_create_a_document_clone',
     ]);
+    if(empty($optionValue['id'])) {
+      return TRUE;
+    }
+
     $optionValue = array_shift($optionValue['values']);
     if (empty($optionValue['value'])) {
       civicrm_api3('OptionValue', 'create', [

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -920,6 +920,29 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Set default number of days before document expiry when the clone document
+   * should be created = 90 days If this field is blank, update it to 90 days.
+   *
+   * @return bool
+   */
+  public function upgrade_1038() {
+    $optionValue = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'ta_settings',
+      'name' => 'days_to_create_a_document_clone',
+    ]);
+    $optionValue = array_shift($optionValue['values']);
+    if (empty($optionValue['value'])) {
+      civicrm_api3('OptionValue', 'create', [
+        'id' => $optionValue['id'],
+        'value' => 90,
+      ]);
+    }
+
+    return TRUE;
+  }
+
   public function uninstall() {
     CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard_tasks', 'ta_dashboard_documents', 'ta_dashboard_calendar', 'ta_dashboard_keydates', 'tasksassignments_administer', 'ta_settings')");
     CRM_Core_BAO_Navigation::resetNavigation();


### PR DESCRIPTION
## Overview
Set default number of days before document expiry when the clone document should be created = 90 days
If this field is blank, update it to 90 days.

## Before
There was an Upgrader function "upgrade_1020" that was setting default days before document expiry to 0.

## After
The new Upgrader function "upgrade_1038" is setting the default number of days to 90 if it is empty or equals to zero. And the existing upgrader  "upgrade_1020" was changed to set default number of days to 90.