### PR TITLE
PCHR-3429: CiviCRM upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
       steps {
         script {
           // Build site with CV Buildkit
-          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 4.7.27 --url $WEBURL --admin-pass $ADMIN_PASS"
+          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.3 --url $WEBURL --admin-pass $ADMIN_PASS"
 
           // Get target and PR branches name
           def prBranch = env.CHANGE_BRANCH

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
       steps {
         script {
           // Build site with CV Buildkit
-          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.3 --url $WEBURL --admin-pass $ADMIN_PASS"
+          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.3.0 --url $WEBURL --admin-pass $ADMIN_PASS"
 
           // Get target and PR branches name
           def prBranch = env.CHANGE_BRANCH

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Activity/Form/ActivityView.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Activity/Form/ActivityView.php
@@ -1,9 +1,9 @@
 <?php
 /*
  +--------------------------------------------------------------------+
- | CiviCRM version 4.7                                                |
+ | CiviCRM version 5                                                  |
  +--------------------------------------------------------------------+
- | Copyright CiviCRM LLC (c) 2004-2017                                |
+ | Copyright CiviCRM LLC (c) 2004-2018                                |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM.                                    |
  |                                                                    |
@@ -28,7 +28,7 @@
 /**
  *
  * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2017
+ * @copyright CiviCRM LLC (c) 2004-2018
  */
 
 /**
@@ -111,6 +111,15 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
 
     $values['attachment'] = CRM_Core_BAO_File::attachmentInfo('civicrm_activity', $activityId);
     $this->assign('values', $values);
+
+    $url = CRM_Utils_System::url(implode("/", $this->urlPath), "reset=1&id={$activityId}&action=view&cid={$values['source_contact_id']}");
+    CRM_Utils_Recent::add($this->_values['subject'],
+      $url,
+      $values['id'],
+      'Activity',
+      $values['source_contact_id'],
+      $values['source_contact']
+    );
   }
 
   /**

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Assignment.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Test/Fabricator/Assignment.php
@@ -27,9 +27,10 @@ class CRM_Tasksassignments_Test_Fabricator_Assignment {
    * assignment.
    */
   private static function setDefaultValues() {
+    $now = date('Y-m-d H:i:s');
     self::$defaultParams = [
-      'subject' => 'A subject ' . ('Y-m-d H:i:s'),
-      'start_date' => ('Y-m-d H:i:s'),
+      'subject' => 'A subject ' . $now,
+      'start_date' => $now,
       'status_id' => 1,
     ];
   }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -214,52 +214,8 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
    * @return bool
    */
   public function upgrade_0007() {
-    $optionGroupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'ta_settings', 'id', 'name');
-
-    if (!$optionGroupID) {
-      $params = array(
-        'name' => 'ta_settings',
-        'title' => 'Tasks and Assignments settings',
-        'is_active' => 1,
-        'is_reserved' => 1,
-      );
-
-      civicrm_api3('OptionGroup', 'create', $params);
-
-      $optionsValue = array(
-        'documents_tab' => array(
-          'label' => 'Show or hide the Documents tab',
-          'value' => 1,
-        ),
-        'keydates_tab' => array(
-          'label' => 'Show or hide the Key Dates tab',
-          'value' => 1,
-        ),
-        'add_assignment_button_title' => array(
-          'label' => 'Configure \'Add Assignment\' button title',
-          'value' => '',
-        ),
-        'number_of_days' => array(
-          'label' => 'No of days prior to Key Date to create task',
-          'value' => 30,
-        ),
-        'auto_tasks_assigned_to' => array(
-          'label' => 'Auto generated Tasks assigned to',
-          'value' => '',
-        ),
-      );
-
-      foreach ($optionsValue as $key => $value) {
-        $opValueParams = array(
-          'option_group_id' => 'ta_settings',
-          'name' => $key,
-          'label' => $value['label'],
-          'value' => $value['value'],
-        );
-
-        civicrm_api3('OptionValue', 'create', $opValueParams);
-      }
-    }
+    // NOOP
+    // This is now done by the postInstall hook
 
     return TRUE;
   }
@@ -415,21 +371,8 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
   }
 
   public function upgrade_1015() {
-    $setting = civicrm_api3('OptionValue', 'get', array(
-      'option_group_id' => 'ta_settings',
-      'name' => 'is_task_dashboard_default',
-    ));
-
-    if (empty($setting['id'])) {
-      $opValueParams = array(
-        'option_group_id' => 'ta_settings',
-        'name' => 'is_task_dashboard_default',
-        'label' => 'Is task dashboard the default page',
-        'value' => '1',
-      );
-      civicrm_api3('OptionValue', 'create', $opValueParams);
-    }
-
+    // NOOP
+    // This is now done by the postInstall hook
     return TRUE;
   }
 
@@ -490,31 +433,8 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1020() {
-    $optionGroupID = CRM_Core_DAO::getFieldValue('CRM_Core_DAO_OptionGroup', 'ta_settings', 'id', 'name');
-
-    if (!$optionGroupID) {
-      civicrm_api3('OptionGroup', 'create', array(
-        'name' => 'ta_settings',
-        'title' => 'Tasks and Assignments settings',
-        'is_active' => 1,
-        'is_reserved' => 1,
-      ));
-    }
-
-    $optionValue = civicrm_api3('OptionValue', 'get', array(
-      'sequential' => 1,
-      'option_group_id' => 'ta_settings',
-      'name' => "days_to_create_a_document_clone",
-    ));
-
-    if (empty($optionValue['id'])) {
-      civicrm_api3('OptionValue', 'create', array(
-        'option_group_id' => 'ta_settings',
-        'name' => 'days_to_create_a_document_clone',
-        'label' => is_callable('t') ? t('Renewed document creation date offset (days)') : 'Renewed document creation date offset (days)',
-        'value' => 0,
-      ));
-    }
+    // NOOP
+    // This is now done by the postInstall Hook
 
     return TRUE;
   }
@@ -927,21 +847,8 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
    * @return bool
    */
   public function upgrade_1038() {
-    $optionValue = civicrm_api3('OptionValue', 'get', [
-      'option_group_id' => 'ta_settings',
-      'name' => 'days_to_create_a_document_clone',
-    ]);
-    if(empty($optionValue['id'])) {
-      return TRUE;
-    }
-
-    $optionValue = array_shift($optionValue['values']);
-    if (empty($optionValue['value'])) {
-      civicrm_api3('OptionValue', 'create', [
-        'id' => $optionValue['id'],
-        'value' => 90,
-      ]);
-    }
+    // NOOP
+    // This is now done by the postInstall hook
 
     return TRUE;
   }

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/TASettings.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/TASettings.php
@@ -40,6 +40,12 @@ function civicrm_api3_t_a_settings_get($params) {
 
   $result = [];
 
+  // safeguard in case this API gets called while the
+  // ta_settings setting is still not available
+  if (empty($settings['ta_settings'])) {
+    return $result;
+  }
+
   foreach ($fields as $field) {
     if (array_key_exists($field, $settings['ta_settings'])) {
       $result[$field] = [

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/TASettings.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/TASettings.php
@@ -1,24 +1,42 @@
 <?php
 
-function civicrm_api3_t_a_settings_get($params) {
-  $fields = [
-    'documents_tab',
-    'keydates_tab',
-    'add_assignment_button_title',
-    'number_of_days',
-    'auto_tasks_assigned_to',
-    'is_task_dashboard_default',
-    'days_to_create_a_document_clone',
+/**
+ * TASettings.get API specification
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_t_a_settings_get_spec(&$spec) {
+  $spec['fields'] = [
+    'name' => 'fields',
+    'title' => 'Fields',
+    'description' => 'Which field(s) you want returned',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 0,
   ];
+}
+
+/**
+ * TASetting.get API
+ *
+ * Used to get one or all of the T&A settings.
+ *
+ * When used without any params, all the settings will be
+ * returned. Otherwise, if the `fields` param is present,
+ * only the given fields will be returned.
+ *
+ * @param array $params
+ *
+ * @return array
+ * @throws \CiviCRM_API3_Exception
+ */
+function civicrm_api3_t_a_settings_get($params) {
+  $fields = _civicrm_api3_t_a_settings_valid_fields();
 
   if (!empty($params['fields'])) {
     $fields = (array) $params['fields'];
   }
 
-  $settings = array_shift(civicrm_api3('Setting', 'get', [
-    'sequential' => 1,
-    'return' => ['ta_settings'],
-  ])['values']);
+  $settings = _civicrm_api3_t_a_settings_get_settings();
 
   $result = [];
 
@@ -34,9 +52,52 @@ function civicrm_api3_t_a_settings_get($params) {
   return civicrm_api3_create_success($result, $params, 'TASettings', 'get');
 }
 
+/**
+ * TASettings.set API specification
+ *
+ * @param array $spec
+ */
+function _civicrm_api3_t_a_settings_set_spec(&$spec) {
+  $spec['fields'] = [
+    'name' => 'fields',
+    'title' => 'Fields',
+    'description' => 'Which field(s) you want set',
+    'type' => CRM_Utils_Type::T_STRING,
+    'api.required' => 1,
+  ];
+}
+
+/**
+ * TASettings.set API
+ *
+ * Used to set a new value in the T&A Settings. Usage:
+ *
+ * civicrm_api3('TASettings', 'set', [
+ *   'field1' => 'bah',
+ *   'field2' => 'foo',
+ *   ...
+ * ])
+ *
+ * @param array $params
+ *
+ * @return array
+ * @throws \CiviCRM_API3_Exception
+ *   An Error will be thrown if any of the given fields doesn't exist
+ */
 function civicrm_api3_t_a_settings_set($params) {
-  foreach ((array) $params['fields'] as $key => $value) {
-    if ($key === 'is_task_dashboard_default') {
+  $validFields = _civicrm_api3_t_a_settings_valid_fields();
+
+  $requestFields = [];
+  if (!empty($params['fields']) && is_array($params['fields'])) {
+    $requestFields = $params['fields'];
+  }
+
+  foreach ($requestFields as $field => $value) {
+    if (!in_array($field, $validFields)) {
+      throw new \CiviCRM_API3_Exception("'{$field}' is not a valid field and cannot be set", 'invalid_field');
+    }
+
+    if ($field === 'is_task_dashboard_default') {
       if ($value == '1') {
         CRM_Tasksassignments_DashboardSwitcher::switchToTasksAndAssignments();
       }
@@ -44,16 +105,13 @@ function civicrm_api3_t_a_settings_set($params) {
         CRM_Tasksassignments_DashboardSwitcher::switchToDefault();
       }
     }
-    if ($key === 'days_to_create_a_document_clone') {
+    if ($field === 'days_to_create_a_document_clone') {
       $value = (int) $value;
     }
 
-    $settings = array_shift(civicrm_api3('Setting', 'get', [
-      'sequential' => 1,
-      'return' => ['ta_settings']
-    ])['values']);
+    $settings = _civicrm_api3_t_a_settings_get_settings();
 
-    $settings['ta_settings'][$key] = $value;
+    $settings['ta_settings'][$field] = $value;
 
     civicrm_api3('Setting', 'create', $settings);
   }
@@ -62,4 +120,36 @@ function civicrm_api3_t_a_settings_set($params) {
     'fields' => array_keys($params['fields']),
     'sequential' => isset($params['sequential']) ? $params['sequential'] : 0,
   ]);
+}
+
+/**
+ * Returns the T&A Settings
+ *
+ * @return array
+ * @throws \CiviCRM_API3_Exception
+ */
+function _civicrm_api3_t_a_settings_get_settings() {
+  $settings = array_shift(civicrm_api3('Setting', 'get', [
+    'sequential' => 1,
+    'return' => ['ta_settings']
+  ])['values']);
+
+  return $settings;
+}
+
+/**
+ * Returns a list of all the valid fields for the T&A Settings
+ *
+ * @return array
+ */
+function _civicrm_api3_t_a_settings_valid_fields() {
+  return [
+    'documents_tab',
+    'keydates_tab',
+    'add_assignment_button_title',
+    'number_of_days',
+    'auto_tasks_assigned_to',
+    'is_task_dashboard_default',
+    'days_to_create_a_document_clone',
+  ];
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/api/v3/TASettings.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/api/v3/TASettings.php
@@ -1,70 +1,72 @@
 <?php
 
 function civicrm_api3_t_a_settings_get($params) {
-    
-    $fields = array(
-        'documents_tab',
-        'keydates_tab',
-        'add_assignment_button_title',
-        'number_of_days',
-        'auto_tasks_assigned_to',
-        'is_task_dashboard_default',
-        'days_to_create_a_document_clone',
-    );
-    
-    if (!empty($params['fields'])) {
-        $fields = (array)$params['fields'];
-    }
-    
-    $result = array();
-    
-    foreach ($fields as $field) {
-        $setting = civicrm_api3('OptionValue', 'get', array(
-            'option_group_id' => 'ta_settings',
-            'name' => $field,
-        ));
-        $item =  CRM_Utils_Array::first($setting['values']);
-        $result[$field] = array(
-            'name' => $item['name'],
-            //'label' => $item['label'],
-            'value' => $item['value'] != "null" ? $item['value'] : ""
-        );
-    }
-    
-    return civicrm_api3_create_success($result, $params, 'TASettings', 'get');
+
+  $fields = [
+    'documents_tab',
+    'keydates_tab',
+    'add_assignment_button_title',
+    'number_of_days',
+    'auto_tasks_assigned_to',
+    'is_task_dashboard_default',
+    'days_to_create_a_document_clone',
+  ];
+
+  if (!empty($params['fields'])) {
+    $fields = (array) $params['fields'];
+  }
+
+  $result = [];
+
+  foreach ($fields as $field) {
+    $setting = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'ta_settings',
+      'name' => $field,
+    ]);
+
+    $item = CRM_Utils_Array::first($setting['values']);
+    $result[$field] = [
+      'name' => $item['name'],
+      //'label' => $item['label'],
+      'value' => $item['value'] != "null" ? $item['value'] : ""
+    ];
+  }
+
+  return civicrm_api3_create_success($result, $params, 'TASettings', 'get');
 }
 
 function civicrm_api3_t_a_settings_set($params) {
-    
-    foreach ((array)$params['fields'] as $key => $value) {
-        if ($key === 'is_task_dashboard_default') {
-            if ($value == '1') {
-                CRM_Tasksassignments_DashboardSwitcher::switchToTasksAndAssignments();
-            } else {
-                CRM_Tasksassignments_DashboardSwitcher::switchToDefault();
-            }
-        }
-        if ($key === 'days_to_create_a_document_clone') {
-          $value = (int)$value;
-        }
 
-        $setting = civicrm_api3('OptionValue', 'get', array(
-            'option_group_id' => 'ta_settings',
-            'name' => $key,
-        ));
-
-        if (empty($setting['id'])) {
-            continue;
-        }
-
-        civicrm_api3('OptionValue', 'create', array(
-            'id' => $setting['id'],
-            'value' => $value,
-        ));
+  foreach ((array) $params['fields'] as $key => $value) {
+    if ($key === 'is_task_dashboard_default') {
+      if ($value == '1') {
+        CRM_Tasksassignments_DashboardSwitcher::switchToTasksAndAssignments();
+      }
+      else {
+        CRM_Tasksassignments_DashboardSwitcher::switchToDefault();
+      }
     }
-    
-    return civicrm_api3('TASettings', 'get', array(
-        'fields' => array_keys($params['fields']),
-        'sequential' => isset($params['sequential']) ? $params['sequential'] : 0,
-    ));
+    if ($key === 'days_to_create_a_document_clone') {
+      $value = (int) $value;
+    }
+
+    $setting = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'ta_settings',
+      'name' => $key,
+    ]);
+
+    if (empty($setting['id'])) {
+      continue;
+    }
+
+    civicrm_api3('OptionValue', 'create', [
+      'id' => $setting['id'],
+      'value' => $value,
+    ]);
+  }
+
+  return civicrm_api3('TASettings', 'get', [
+    'fields' => array_keys($params['fields']),
+    'sequential' => isset($params['sequential']) ? $params['sequential'] : 0,
+  ]);
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/settings/tasksandassignments.setting.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/settings/tasksandassignments.setting.php
@@ -1,0 +1,18 @@
+<?php
+
+  return [
+    'ta_settings' => [
+      'group_name' => 'Task & Assignments Settings',
+      'group' => 'ta_settings',
+      'name' => 'ta_settings',
+      'type' => 'Array',
+      'description' => 'Task & Assignments Settings',
+      'label' =>  'Task & Assignments Settings',
+      'html_type' => 'addSelect',
+      'is_domain' => 0,
+      'html_attributes' => [
+        'style' => 'width:350px',
+      ],
+      'quick_form_type' => 'Element',
+    ],
+  ];

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -59,6 +59,15 @@ function tasksassignments_civicrm_install() {
 }
 
 /**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall/
+ */
+function tasksassignments_civicrm_postInstall() {
+  _taskassignments_saveDefaultSettings();
+}
+
+/**
  * Implements hook_civicrm_uninstall().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
@@ -542,4 +551,23 @@ function _tasksAssignments_remove_columns_from_timeline(phpQueryObject $doc) {
 function _tasksAssignments_change_column_text(phpQueryObject $doc) {
   $doc->find('th:contains("Activity")')
     ->text('Task / Document Type');
+}
+
+/**
+ * Sets the default values for the T&A Settings
+ *
+ * @throws \CiviCRM_API3_Exception
+ */
+function _taskassignments_saveDefaultSettings() {
+  civicrm_api3('TASettings', 'set', [
+    'fields' => [
+      'documents_tab' => 1,
+      'keydates_tab' => 1,
+      'add_assignment_button_title' => '',
+      'number_of_days' => 30,
+      'auto_tasks_assigned_to' => '',
+      'is_task_dashboard_default' => 1,
+      'days_to_create_a_document_clone' => 90
+    ]
+  ]);
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TASettingsTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TASettingsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use CRM_Tasksassignments_Test_BaseHeadlessTest as BaseHeadlessTest;
+
+/**
+ * Class api_v3_TaskTest
+ *
+ * @group headless
+ */
+class api_v3_TASettingsTest extends BaseHeadlessTest {
+
+  private $validFields;
+  private $defaultSettings;
+
+  public function setUp() {
+    $this->validFields = $this->getValidFields();
+
+    foreach($this->validFields as $field) {
+      $this->defaultSettings[$field] = '1';
+    }
+
+    civicrm_api3('TASettings', 'set', [
+      'fields' => $this->defaultSettings
+    ]);
+  }
+
+  public function testGetReturnsAllTheSettingsWhenCallWithoutParams() {
+    $result = civicrm_api3('TASettings', 'get');
+
+    $this->assertCount(count($this->validFields), $result['values']);
+
+    foreach ($this->defaultSettings as $setting => $value) {
+      $expected = [
+        'name' => $setting,
+        'value' => $value,
+      ];
+
+      $this->assertEquals($expected, $result['values'][$setting]);
+    }
+  }
+
+  public function testGetReturnsOnlyTheSpecifiedFieldsWhenTheFieldsParamIsPassed() {
+    $field = $this->validFields[array_rand($this->validFields)];
+
+    $result = civicrm_api3('TASettings', 'get', [
+      'sequential' => 1,
+      'fields' => [$field]
+    ]);
+
+    $expected = [
+      'name' => $field,
+      'value' => $this->defaultSettings[$field]
+    ];
+
+    $this->assertEquals($expected, $result['values'][0]);
+  }
+
+  public function testSetUpdatesSettingsValuesAndReturnTheUpdatedValues() {
+    $randKeys = array_rand($this->validFields, 2);
+
+    $field1 = $this->validFields[$randKeys[0]];
+    $field2 = $this->validFields[$randKeys[1]];
+
+    $field1Value = 999999;
+    $field2Value = 888;
+
+    $result = civicrm_api3('TASettings', 'set', [
+      'fields' => [
+        $field1 => $field1Value,
+        $field2 => $field2Value
+      ]
+    ]);
+
+    $expected = [
+      $field1 => [
+        'name' => $field1,
+        'value' => $field1Value
+      ],
+      $field2 => [
+        'name' => $field2,
+        'value' => $field2Value
+      ]
+    ];
+
+    $this->assertEquals($expected, $result['values']);
+  }
+
+  private function getValidFields() {
+    $result = civicrm_api3('OptionValue', 'get', [
+      'sequential' => 1,
+      'option_group_id' => 'ta_settings',
+      'return' => ['name']
+    ]);
+
+    return array_column($result['values'], 'name');
+  }
+
+}

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TASettingsTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TASettingsTest.php
@@ -86,13 +86,7 @@ class api_v3_TASettingsTest extends BaseHeadlessTest {
   }
 
   private function getValidFields() {
-    $result = civicrm_api3('OptionValue', 'get', [
-      'sequential' => 1,
-      'option_group_id' => 'ta_settings',
-      'return' => ['name']
-    ]);
-
-    return array_column($result['values'], 'name');
+    return _civicrm_api3_t_a_settings_valid_fields();
   }
 
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TASettingsTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TASettingsTest.php
@@ -85,8 +85,49 @@ class api_v3_TASettingsTest extends BaseHeadlessTest {
     $this->assertEquals($expected, $result['values']);
   }
 
+  public function testSetUpdatesDashboardUrlToTasksAndAssignmentsWhenIsTaskDashboardIs1() {
+    $this->setHomeNavigationUrl('foo');
+    $this->assertEquals('foo', $this->getHomeNavigationUrl());
+
+    civicrm_api3('TASettings', 'set', [
+      'fields' => [
+        'is_task_dashboard_default' => 1
+      ]
+    ]);
+
+    $this->assertEquals('civicrm/tasksassignments/dashboard#/tasks', $this->getHomeNavigationUrl());
+  }
+
+  public function testSetUpdatesDashboardUrlToDefaultCiviDashboardWhenIsTaskDashboardIsNot1() {
+    $this->setHomeNavigationUrl('foo');
+    $this->assertEquals('foo', $this->getHomeNavigationUrl());
+
+    civicrm_api3('TASettings', 'set', [
+      'fields' => [
+        'is_task_dashboard_default' => 0
+      ]
+    ]);
+
+    $this->assertEquals('civicrm/dashboard?reset=1', $this->getHomeNavigationUrl());
+  }
+
   private function getValidFields() {
     return _civicrm_api3_t_a_settings_valid_fields();
   }
 
+  private function setHomeNavigationUrl($url) {
+    CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET url=%1 WHERE name='Home'", [
+      1 => [
+        $url,
+        'String'
+      ]
+    ]);
+  }
+
+  private function getHomeNavigationUrl() {
+    $result = CRM_Core_DAO::executeQuery("SELECT url FROM civicrm_navigation WHERE name='Home'");
+    $result->fetch();
+
+    return $result->url;
+  }
 }


### PR DESCRIPTION
## Overview

This PR is part of https://github.com/compucorp/civihr/pull/2720 and updates Tasks and Assignments so that it can be used with CiviCRM 5.3.0. It includes fixes for things that stopped working after the upgrade, syncing of overridden files and some minor fixes not related to the upgrade. See "Technical Details" for more information.

## Before

The extension could not be used with CiviCRM 5.3.0

## After

The extension can be used with CiviCRM 5.3.0

## Technical Details

### Refactoring of the TASettings API

This extension has its own API to save and fetch settings: `TASettings`. Internally, this API would use Option Values to store the settings. That is, each setting was an Option Value in the `ta_settings` Option Value, and the value was the setting value. Whenever a setting was updated, the Option Value value was updated as well. Because of that, it was possible to have more than one Option Value with the same value and since it's not possible anymore to have that (https://github.com/civicrm/civicrm-core/pull/11089), the installation was failing.

The reasons for this implementation are unknown, as the code is quite old and undocumented. Maybe it made sense back when it was implemented, but today the proper solution for this is to use [CiviCRM settings](https://docs.civicrm.org/dev/en/latest/framework/setting/) and the `TASettings` API was refactored to use that:

- First, the code style was fixed to use the conventions we use today https://github.com/compucorp/civihr-tasks-assignments/pull/380/commits/6fbbb190bd447cb1b17e2ca43417220ebd90d6ab
- Next, tests were added to cover the existing behavior and make sure not would break after the refactoring: https://github.com/compucorp/civihr-tasks-assignments/pull/380/commits/ce858eca5c0bb1698a814a84c61db08683e3ca2d
- Then a new `ta_settings` setting was added to store the values using CiviCRM Settings. The internal implementation of the API was updated to use that instead of Option Values: https://github.com/compucorp/civihr-tasks-assignments/pull/380/commits/ca56053096155e0d88741560177438ad55e0e1c2
- Next, I made sure the `ta_settings` Option Group would not be created on new installs: https://github.com/compucorp/civihr-tasks-assignments/pull/380/commits/bd865064149b95382adb16e1e52dddc9e68d5c26
- And finally, for existing sites, migrated the settings in Option Values to CiviCRM settings and deleted the Option Group.

While doing that, I also made one small improvement to the API where I validated the settings before saving them. This was necessary because the `ta_settings` setting is an array and without the validation, any field passed to it would end up being stored in the settings. The validation was added here: https://github.com/compucorp/civihr-tasks-assignments/pull/380/commits/b6e6bc5a0524aad30cead2e71c957b0b26c7d1fd

### Syncing overridden files

The extension has only one overridden file to be synced:

- `CRM/Activity/Form/ActivityView.php`: [diff](https://www.diffchecker.com/S9UswuPk)

### Default date in the Assignment Fabricator

This is the code that would set the default `start_date` for an Assigment:

```
'start_date' => ('Y-m-d H:i:s')
```

The problem is that `('Y-m-d H:i:s')` is not a valid date and when passed to the API to build the SQL query, that would be converted to 0 which would result in a database error. 

To fix that, I simply changed the line to:

```
'start_date' => date('Y-m-d H:i:s')
```

I've spend quite a lot of time trying to figure out why this never failed before, but I couldn't. The most likely reason is that something about saving cases changed in civicrm-core but I'm not sure.

