### PR TITLE
PCHR-4008: CiviCRM 5.3.1 upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
       steps {
         script {
           // Build site with CV Buildkit
-          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.3.0 --url $WEBURL --admin-pass $ADMIN_PASS"
+          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.3.1 --url $WEBURL --admin-pass $ADMIN_PASS"
 
           // Get target and PR branches name
           def prBranch = env.CHANGE_BRANCH

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Activity/Form/ActivityView.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Activity/Form/ActivityView.php
@@ -42,7 +42,7 @@ class CRM_Activity_Form_ActivityView extends CRM_Core_Form {
   public function preProcess() {
     // Get the activity values.
     $activityId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
-    $context = CRM_Utils_Request::retrieve('context', 'String', $this);
+    $context = CRM_Utils_Request::retrieve('context', 'Alphanumeric', $this);
     $cid = CRM_Utils_Request::retrieve('cid', 'Positive', $this);
 
     // Check for required permissions, CRM-6264.


### PR DESCRIPTION
This PR include a couple of small updates to make CiviHR compatible with CiviCRM 5.3.1:

- The `Jenkinsfile` was updated to run the tests using CiviCRM 5.3.1 (a 5.3.1 patches branch was also created in our fork of civicrm-core)
- Overridden files were synced