### PR TITLE
PCHR-4050: Move back upgrader for creating case type category field

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -912,6 +912,50 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
     return TRUE;
   }
 
+  /**
+   * Sets up option values, custom group and custom field
+   * for case type categorization
+   *
+   * @return bool
+   */
+  public function upgrade_1041() {
+    $optionValues = civicrm_api3('OptionValue', 'get', [
+      'option_group_id' => 'cg_extend_objects',
+      'name' => 'civicrm_case_type'
+    ]);
+    if ($optionValues['count'] == 0) {
+      $params = [
+        'option_group_id' => 'cg_extend_objects',
+        'name' => 'civicrm_case_type',
+        'label' => ts('Case Type'),
+        'value' => 'CaseType',
+      ];
+      $this->_createOptionValue($params);
+    }
+
+    $customGroups = civicrm_api3('CustomGroup', 'get', [
+      'extends' => 'CaseType',
+      'name' => 'case_type_category',
+    ]);
+    if ($customGroups['count'] == 0) {
+      $this->_createCaseTypeCategoryCustomGroup();
+    }
+
+    $customFields = civicrm_api3('CustomField', 'get', [
+      'custom_group_id' => 'case_type_category',
+    ]);
+    if ($customFields['count'] == 0) {
+      $optionGroupId = $this->_createCaseTypeCategoryOptionValues();
+      if ($optionGroupId == null) {
+        return FALSE;
+      }
+
+      $this->_createCaseTypeCategoryCustomField($optionGroupId);
+    }
+
+    return TRUE;
+  }
+
   public function uninstall() {
     CRM_Core_DAO::executeQuery("DELETE FROM `civicrm_navigation` WHERE name IN ('tasksassignments', 'ta_dashboard_tasks', 'ta_dashboard_documents', 'ta_dashboard_calendar', 'ta_dashboard_keydates', 'tasksassignments_administer', 'ta_settings')");
     CRM_Core_BAO_Navigation::resetNavigation();
@@ -1084,6 +1128,89 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
       'api.OptionGroup.delete' => [
         'id' => '$value.id'
       ]
+    ]);
+  }
+
+  /**
+   * Creates option group
+   *
+   * @param array $params
+   *
+   * @return array
+   */
+  private function _createOptionGroup($params) {
+    return civicrm_api3('OptionGroup', 'create', $params);
+  }
+
+  /**
+   * Creates option value
+   *
+   * @param array $params
+   */
+  private function _createOptionValue($params) {
+    civicrm_api3('OptionValue', 'create', $params);
+  }
+
+  /**
+   * Creates case type category custom group
+   */
+  private function _createCaseTypeCategoryCustomGroup() {
+    civicrm_api3('CustomGroup', 'create', [
+      'title' => ts('Case Type Category'),
+      'extends' => 'CaseType',
+      'name' => 'case_type_category',
+      'table_name' => 'civicrm_value_case_type_category'
+    ]);
+  }
+
+  /**
+   * Sets up option group and values used for case type category custom field
+   *
+   * @return null
+   */
+  private function _createCaseTypeCategoryOptionValues() {
+    $result = civicrm_api3('OptionGroup', 'get', [
+      'name' => 'case_type_category',
+    ]);
+    if ($result['count'] == 0) {
+      $optionValues = ['Workflow', 'Vacancy'];
+      $groupParams = [
+        'name' => 'case_type_category',
+        'title' => 'Category',
+      ];
+
+      $optionGroupResult = $this->_createOptionGroup($groupParams);
+      foreach ($optionValues as $optionValue) {
+        $valueParams = [
+          'option_group_id' => 'case_type_category',
+          'label' => $optionValue,
+          'name' => $optionValue,
+          'value' => $optionValue
+        ];
+        $this->_createOptionValue($valueParams);
+      }
+
+      return $optionGroupResult['id'];
+    }
+
+    return null;
+  }
+
+  /**
+   * Creates category custom field for case type category custom group
+   *
+   * @param int $optionGroupId
+   */
+  private function _createCaseTypeCategoryCustomField($optionGroupId) {
+    civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => 'case_type_category',
+      'label' => 'Category',
+      'name' => 'category',
+      'data_type' => 'String',
+      'html_type' => 'Select',
+      'is_required' => 1,
+      'column_name' => 'category',
+      'option_group_id' => $optionGroupId,
     ]);
   }
 


### PR DESCRIPTION
## Overview
This PR moves the creation of the case type category field back to Tasks and Assignment. The upgrader was first moved to HRCore in this PR https://github.com/compucorp/civihr/pull/2799 in order to fix case categorization on test sites, but the upgrader did not work as intended.

What has been tested both on local sites and test sites is to have the upgrader for creating the custom field in Tasks and Workflow, and leave the case type categorization on HRCase as intended by the previous PR.

### API result from test site:

```json
{

    "is_error": 0,
    "version": 3,
    "count": 3,
    "values": [
        {
            "id": "8",
            "title": "Application",
            "custom_100022": "Vacancy",
            "is_forkable": "1",
            "is_forked": "1"
        },
        {
            "id": "18",
            "title": "Exiting",
            "custom_100022": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "19",
            "title": "Joining",
            "custom_100022": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        }
    ]
}
```

### API result from local sites

```json
{

    "is_error": 0,
    "version": 3,
    "count": 5,
    "values": [
        {
            "id": "1",
            "title": "Housing Support",
            "custom_66": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "2",
            "title": "Adult Day Care Referral",
            "custom_66": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "3",
            "title": "Exiting",
            "custom_66": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "4",
            "title": "Joining",
            "custom_66": "Workflow",
            "is_forkable": "1",
            "is_forked": ""
        },
        {
            "id": "5",
            "title": "Application",
            "is_forkable": "1",
            "is_forked": ""
        }
    ]
}
```

### Notes

* `custom_###` is the custom category field name
* The extra case types on the local site must be also an issue with the order the upgraders run, but it's not part of the scope of this PR.

## Technical Details
Having the upgrader for the custom field in T&W and the case type categorization in HRCase works because HRCase depends on T&W, but not on HRCore, as it was suspected by the previous PR. This means that the custom field is created before the categorization in HRCase starts.
