### PR TITLE
PCHR-4166: Set Jenkins failure threshold to 0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,10 +85,10 @@ pipeline {
                 thresholds: [
                   [
                     $class: 'FailedThreshold',
-                    failureNewThreshold: '1',
-                    failureThreshold: '1',
-                    unstableNewThreshold: '1',
-                    unstableThreshold: '1'
+                    failureNewThreshold: '0',
+                    failureThreshold: '0',
+                    unstableNewThreshold: '0',
+                    unstableThreshold: '0'
                   ]
                 ],
                 tools: [
@@ -119,10 +119,10 @@ pipeline {
                 thresholds: [
                   [
                     $class: 'FailedThreshold',
-                    failureNewThreshold: '1',
-                    failureThreshold: '1',
-                    unstableNewThreshold: '1',
-                    unstableThreshold: '1'
+                    failureNewThreshold: '0',
+                    failureThreshold: '0',
+                    unstableNewThreshold: '0',
+                    unstableThreshold: '0'
                   ]
                 ],
                 tools: [


### PR DESCRIPTION
See https://github.com/compucorp/civihr/pull/2853

Note: The failure in this PR is not caused by this change. It was introduced by https://github.com/compucorp/civihr-tasks-assignments/pull/385, but because the threshold was wrong when the PR was merged, we didn't catch the failure. https://github.com/compucorp/civihr-tasks-assignments/pull/420 will fix it.