### PR TITLE
PCHR-4346: CiviCRM Upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
       steps {
         script {
           // Build site with CV Buildkit
-          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.3.1 --url $WEBURL --admin-pass $ADMIN_PASS"
+          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.7 --url $WEBURL --admin-pass $ADMIN_PASS"
 
           // Get target and PR branches name
           def prBranch = env.CHANGE_BRANCH

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
       steps {
         script {
           // Build site with CV Buildkit
-          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.7 --url $WEBURL --admin-pass $ADMIN_PASS"
+          sh "civibuild create ${params.BUILDNAME} --type drupal-clean --civi-ver 5.7.0 --url $WEBURL --admin-pass $ADMIN_PASS"
 
           // Get target and PR branches name
           def prBranch = env.CHANGE_BRANCH

--- a/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tasksassignments.php
@@ -238,7 +238,7 @@ function tasksassignments_civicrm_tabset($tabsetName, &$tabs, $context) {
           'id'        => 'cividocuments',
           'url'       => CRM_Utils_System::url('civicrm/contact/view/documents'),
           'title'     => ts('Documents'),
-          'weight'    => 50,
+          'weight'    => 75,
         );
       }
     }


### PR DESCRIPTION
## Overview

This PR is part of the updates to make CiviHR compatible with CiviCRM 5.7.0. The other part of the work was done in https://github.com/compucorp/civihr/pull/2899.

## Technical Details

In CiviHR, we use `hook_civicrm_tabset` in multiple extensions to make sure the tabs in the Contact page will be displayed in some specific order. This order mandates that the "Documents" tab should be displayed after the "Communications" (activities, internally). However, due to a [recent cleanup](https://github.com/civicrm/civicrm-core/pull/12941) in CiviCRM core, the order of these two items was inverted after upgrading to 5.7.0. The reason is that after the cleanup, the "Communications" tab now has a [hardcoded weight of 70](https://github.com/colemanw/civicrm-core/blob/42e8679229d13e5112002a888075ed4b4d156057/CRM/Contact/Page/View/Summary.php#L321-L325) and since the weight of "Documents" was set to 60, it started being display before "Communications". To fix this, I changed the weight to 75, making it greater than 70 but also leaving some room for any other possible items in the future.