### PR TITLE
PCHR-4356: Fix regression issues when syncing with latest Shoreditch release

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -12377,14 +12377,14 @@ fieldset[disabled]
 #civitasks .civihr-ui-select.open, #cividocuments .civihr-ui-select.open, #civitasks .civihr-ui-select .select2-drop-active, #cividocuments .civihr-ui-select .select2-drop-active, #civitasks .civihr-ui-select.ui-select-multiple .select2-drop-active, #cividocuments .civihr-ui-select.ui-select-multiple .select2-drop-active {
   background: #fff !important;
 }
-#civitasks .civihr-ui-select .select2-search-choice-close, #cividocuments .civihr-ui-select .select2-search-choice-close, #civitasks .civihr-ui-select.open .select2-chosen, #cividocuments .civihr-ui-select.open .select2-chosen, #civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select a.select2-choice, #cividocuments .civihr-ui-select a.select2-choice, #civitasks .civihr-ui-select .ui-select-search, #cividocuments .civihr-ui-select .ui-select-search, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
+#civitasks .civihr-ui-select.open .select2-chosen, #cividocuments .civihr-ui-select.open .select2-chosen, #civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select a.select2-choice, #cividocuments .civihr-ui-select a.select2-choice, #civitasks .civihr-ui-select .ui-select-search, #cividocuments .civihr-ui-select .ui-select-search, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
   background: none !important;
 }
 #civitasks .civihr-ui-select.open .select2-chosen, #cividocuments .civihr-ui-select.open .select2-chosen, #civitasks .civihr-ui-select.open .ui-select-search, #cividocuments .civihr-ui-select.open .ui-select-search, #civitasks .civihr-ui-select.ui-select-multiple, #cividocuments .civihr-ui-select.ui-select-multiple, #civitasks .civihr-ui-select.ui-select-multiple .ui-select-match-item, #cividocuments .civihr-ui-select.ui-select-multiple .ui-select-match-item, #civitasks .civihr-ui-select .select2-drop-active, #cividocuments .civihr-ui-select .select2-drop-active {
   border-width: 1px !important;
   border-style: solid !important;
 }
-#civitasks .civihr-ui-select .select2-search-choice-close::before, #cividocuments .civihr-ui-select .select2-search-choice-close::before, #civitasks .civihr-ui-select.open .select2-search::after, #cividocuments .civihr-ui-select.open .select2-search::after, #civitasks .civihr-ui-select .select2-arrow::before, #cividocuments .civihr-ui-select .select2-arrow::before, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
+#civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
   font-family: 'FontAwesome';
   font-style: normal;
   text-rendering: auto;
@@ -12393,7 +12393,7 @@ fieldset[disabled]
 #civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select:not(.open) .select2-chosen, #cividocuments .civihr-ui-select:not(.open) .select2-chosen, #civitasks .civihr-ui-select .select2-input, #cividocuments .civihr-ui-select .select2-input, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
   line-height: 28px !important;
 }
-#civitasks .civihr-ui-select .select2-search-choice-close::before, #cividocuments .civihr-ui-select .select2-search-choice-close::before, #civitasks .civihr-ui-select .select2-chosen, #cividocuments .civihr-ui-select .select2-chosen, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
+#civitasks .civihr-ui-select .select2-chosen, #cividocuments .civihr-ui-select .select2-chosen, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
   font-size: 13px !important;
 }
 #civitasks .civihr-ui-select.open .select2-arrow, #cividocuments .civihr-ui-select.open .select2-arrow, #civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select .ui-select-choices, #cividocuments .civihr-ui-select .ui-select-choices, #civitasks .civihr-ui-select.ui-select-multiple.open .select2-search-field, #cividocuments .civihr-ui-select.ui-select-multiple.open .select2-search-field, #civitasks .civihr-ui-select:not(.open) .select2-choice, #cividocuments .civihr-ui-select:not(.open) .select2-choice {
@@ -12428,21 +12428,7 @@ fieldset[disabled]
   border-radius: 0 0 2px 2px !important;
 }
 #civitasks .civihr-ui-select .select2-search-choice-close, #cividocuments .civihr-ui-select .select2-search-choice-close {
-  height: 15px;
-  left: unset !important;
   right: 45px !important;
-  width: 15px !important;
-}
-#civitasks .civihr-ui-select .select2-search-choice-close, #cividocuments .civihr-ui-select .select2-search-choice-close {
-  background: none !important;
-  top: 2px !important;
-}
-#civitasks .civihr-ui-select .select2-search-choice-close::before, #cividocuments .civihr-ui-select .select2-search-choice-close::before {
-  content: '\f057';
-  line-height: inherit !important;
-  vertical-align: middle !important;
-  text-align: right;
-  display: block;
 }
 #civitasks .civihr-ui-select.open:not(.ng-invalid), #cividocuments .civihr-ui-select.open:not(.ng-invalid),
 #civitasks .civihr-ui-select.open:not(.ng-invalid) *,
@@ -12471,11 +12457,8 @@ fieldset[disabled]
 #civitasks .civihr-ui-select.open .select2-search-choice-close::before, #cividocuments .civihr-ui-select.open .select2-search-choice-close::before {
   display: none;
 }
-#civitasks .civihr-ui-select.open .select2-search::after, #cividocuments .civihr-ui-select.open .select2-search::after {
-  position: relative;
-  content: '\f002';
-  color: #586277 !important;
-  right: 30px;
+#civitasks .civihr-ui-select.open .select2-arrow::before, #cividocuments .civihr-ui-select.open .select2-arrow::before {
+  right: 2px;
 }
 #civitasks .civihr-ui-select:not(.open), #cividocuments .civihr-ui-select:not(.open) {
   border-color: #C2CFD8 !important;
@@ -12486,13 +12469,6 @@ fieldset[disabled]
 }
 #civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow {
   width: 31px !important;
-}
-#civitasks .civihr-ui-select:not(.open) .select2-arrow::before, #cividocuments .civihr-ui-select:not(.open) .select2-arrow::before {
-  width: 100%;
-  display: block;
-  text-align: center;
-  line-height: 30px;
-  content: '\f0d7';
 }
 .contact-lookup#civitasks .civihr-ui-select:not(.open) .select2-arrow::before, .contact-lookup#cividocuments .civihr-ui-select:not(.open) .select2-arrow::before {
   content: '\f002' !important;
@@ -12519,10 +12495,6 @@ fieldset[disabled]
   cursor: pointer !important;
   right: 0 !important;
   top: 0 !important;
-}
-#civitasks .civihr-ui-select .select2-arrow::before, #cividocuments .civihr-ui-select .select2-arrow::before {
-  color: #4D4D69;
-  content: '\f0d8';
 }
 #civitasks .civihr-ui-select .select2-chosen, #cividocuments .civihr-ui-select .select2-chosen {
   color: #4D4D69 !important;
@@ -12723,10 +12695,6 @@ fieldset[disabled]
 #civitasks .civihr-ui-select .select2-search-choice, #cividocuments .civihr-ui-select .select2-search-choice {
   font-size: 13px;
 }
-#civitasks .civihr-ui-select .select2-search-choice-close, #cividocuments .civihr-ui-select .select2-search-choice-close {
-  background: none !important;
-  top: 3px !important;
-}
 #civitasks .civihr-ui-select a.select2-search-choice-close, #cividocuments .civihr-ui-select a.select2-search-choice-close {
   /* stylelint-disable-line selector-no-qualifying-type */
   top: 0 !important;
@@ -12735,9 +12703,6 @@ fieldset[disabled]
   border: 1px solid #C2CFD8 !important;
   border-bottom: 0 !important;
   padding-left: 12px !important;
-}
-#civitasks .civihr-ui-select.open .select2-arrow, #cividocuments .civihr-ui-select.open .select2-arrow {
-  line-height: 31px;
 }
 #civitasks .civihr-ui-select .select2-drop-active, #cividocuments .civihr-ui-select .select2-drop-active {
   border-top: 0 !important;

--- a/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
+++ b/uk.co.compucorp.civicrm.tasksassignments/css/civitasks.css
@@ -12377,23 +12377,17 @@ fieldset[disabled]
 #civitasks .civihr-ui-select.open, #cividocuments .civihr-ui-select.open, #civitasks .civihr-ui-select .select2-drop-active, #cividocuments .civihr-ui-select .select2-drop-active, #civitasks .civihr-ui-select.ui-select-multiple .select2-drop-active, #cividocuments .civihr-ui-select.ui-select-multiple .select2-drop-active {
   background: #fff !important;
 }
-#civitasks .civihr-ui-select.open .select2-chosen, #cividocuments .civihr-ui-select.open .select2-chosen, #civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select a.select2-choice, #cividocuments .civihr-ui-select a.select2-choice, #civitasks .civihr-ui-select .ui-select-search, #cividocuments .civihr-ui-select .ui-select-search, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
+#civitasks .civihr-ui-select.open .select2-chosen, #cividocuments .civihr-ui-select.open .select2-chosen, #civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select a.select2-choice, #cividocuments .civihr-ui-select a.select2-choice, #civitasks .civihr-ui-select .ui-select-search, #cividocuments .civihr-ui-select .ui-select-search {
   background: none !important;
 }
 #civitasks .civihr-ui-select.open .select2-chosen, #cividocuments .civihr-ui-select.open .select2-chosen, #civitasks .civihr-ui-select.open .ui-select-search, #cividocuments .civihr-ui-select.open .ui-select-search, #civitasks .civihr-ui-select.ui-select-multiple, #cividocuments .civihr-ui-select.ui-select-multiple, #civitasks .civihr-ui-select.ui-select-multiple .ui-select-match-item, #cividocuments .civihr-ui-select.ui-select-multiple .ui-select-match-item, #civitasks .civihr-ui-select .select2-drop-active, #cividocuments .civihr-ui-select .select2-drop-active {
-  border-width: 1px !important;
   border-style: solid !important;
+  border-width: 1px !important;
 }
-#civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
-  font-family: 'FontAwesome';
-  font-style: normal;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-}
-#civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select:not(.open) .select2-chosen, #cividocuments .civihr-ui-select:not(.open) .select2-chosen, #civitasks .civihr-ui-select .select2-input, #cividocuments .civihr-ui-select .select2-input, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
+#civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select:not(.open) .select2-chosen, #cividocuments .civihr-ui-select:not(.open) .select2-chosen, #civitasks .civihr-ui-select .select2-input, #cividocuments .civihr-ui-select .select2-input {
   line-height: 28px !important;
 }
-#civitasks .civihr-ui-select .select2-chosen, #cividocuments .civihr-ui-select .select2-chosen, #civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
+#civitasks .civihr-ui-select .select2-chosen, #cividocuments .civihr-ui-select .select2-chosen {
   font-size: 13px !important;
 }
 #civitasks .civihr-ui-select.open .select2-arrow, #cividocuments .civihr-ui-select.open .select2-arrow, #civitasks .civihr-ui-select:not(.open) .select2-arrow, #cividocuments .civihr-ui-select:not(.open) .select2-arrow, #civitasks .civihr-ui-select .ui-select-choices, #cividocuments .civihr-ui-select .ui-select-choices, #civitasks .civihr-ui-select.ui-select-multiple.open .select2-search-field, #cividocuments .civihr-ui-select.ui-select-multiple.open .select2-search-field, #civitasks .civihr-ui-select:not(.open) .select2-choice, #cividocuments .civihr-ui-select:not(.open) .select2-choice {
@@ -12404,9 +12398,9 @@ fieldset[disabled]
   width: 100% !important;
 }
 #civitasks .civihr-ui-select:not(.open).form-control.select2-container-disabled, #cividocuments .civihr-ui-select:not(.open).form-control.select2-container-disabled {
-  color: #8b8baa !important;
-  border-color: #8b8baa !important;
   background: #F3F6F7 !important;
+  border-color: #8b8baa !important;
+  color: #8b8baa !important;
 }
 #civitasks .civihr-ui-select:not(.open).form-control.select2-container-disabled .select2-chosen, #cividocuments .civihr-ui-select:not(.open).form-control.select2-container-disabled .select2-chosen {
   color: #8b8baa !important;
@@ -12442,8 +12436,8 @@ fieldset[disabled]
   border: 0 !important;
 }
 #civitasks .civihr-ui-select.open .select2-chosen > span:first-of-type, #cividocuments .civihr-ui-select.open .select2-chosen > span:first-of-type {
-  max-width: calc(100% - 20px);
   display: block;
+  max-width: calc(100% - 20px);
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -12451,8 +12445,8 @@ fieldset[disabled]
   border-bottom: 0 !important;
 }
 #civitasks .civihr-ui-select.open .ui-select-search, #cividocuments .civihr-ui-select.open .ui-select-search {
-  padding: 0 5px !important;
   margin-top: 5px !important;
+  padding: 0 5px !important;
 }
 #civitasks .civihr-ui-select.open .select2-search-choice-close::before, #cividocuments .civihr-ui-select.open .select2-search-choice-close::before {
   display: none;
@@ -12501,8 +12495,8 @@ fieldset[disabled]
   padding-left: 5px !important;
 }
 #civitasks .civihr-ui-select .select2-drop-active, #cividocuments .civihr-ui-select .select2-drop-active {
-  border-top: 0 !important;
   border-style: solid;
+  border-top: 0 !important;
   border-width: 1px !important;
   opacity: 1 !important;
 }
@@ -12516,8 +12510,8 @@ fieldset[disabled]
   margin: 5px 0 0 !important;
 }
 #civitasks .civihr-ui-select .select2-result-label, #cividocuments .civihr-ui-select .select2-result-label {
-  padding: 5px 10px !important;
   color: #4D4D69;
+  padding: 5px 10px !important;
 }
 #civitasks .civihr-ui-select .select2-highlighted, #cividocuments .civihr-ui-select .select2-highlighted {
   background: #F3F6F7 !important;
@@ -12526,12 +12520,12 @@ fieldset[disabled]
   height: 100% !important;
 }
 #civitasks .civihr-ui-select.ui-select-multiple .ui-select-match-item, #cividocuments .civihr-ui-select.ui-select-multiple .ui-select-match-item {
+  background: none;
+  border-radius: 0 !important;
   box-sizing: border-box !important;
   line-height: 17px !important;
   margin: 5px 5px 5px 0 !important;
   padding: 0 22px 0 5px !important;
-  border-radius: 0 !important;
-  background: none;
 }
 #civitasks .civihr-ui-select.ui-select-multiple .ui-select-match-item .select2-search-choice-close, #cividocuments .civihr-ui-select.ui-select-multiple .ui-select-match-item .select2-search-choice-close {
   right: 5px !important;
@@ -12541,23 +12535,14 @@ fieldset[disabled]
   display: block;
 }
 #civitasks .civihr-ui-select.ui-select-multiple .select2-choices, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices {
+  background: none !important;
+  background-image: none !important;
+  border: 0;
   box-shadow: none !important;
+  margin-bottom: 0 !important;
   -moz-padding-start: 0 !important;
   -webkit-padding-start: 0 !important;
-  margin-bottom: 0 !important;
   width: 100% !important;
-  border: 0;
-  background-image: none !important;
-  background: none !important;
-}
-#civitasks .civihr-ui-select.ui-select-multiple .select2-choices::before, #cividocuments .civihr-ui-select.ui-select-multiple .select2-choices::before {
-  color: #4D4D69;
-  padding-left: 13px !important;
-  width: 26px !important;
-  height: 30px;
-  top: 0 !important;
-  pointer-events: none;
-  position: absolute;
 }
 #civitasks .civihr-ui-select.ui-select-multiple:not(.open), #cividocuments .civihr-ui-select.ui-select-multiple:not(.open) {
   border-color: #C2CFD8 !important;
@@ -12582,13 +12567,13 @@ fieldset[disabled]
   margin: 0 !important;
 }
 #civitasks .civihr-ui-select.ui-select-multiple.open .select2-chosen, #cividocuments .civihr-ui-select.ui-select-multiple.open .select2-chosen {
-  min-height: 25px !important;
   border: 0 !important;
   line-height: 25px;
+  min-height: 25px !important;
 }
 #civitasks .civihr-ui-select.ui-select-multiple .select2-drop-active, #cividocuments .civihr-ui-select.ui-select-multiple .select2-drop-active {
-  left: -1px;
   box-sizing: content-box !important;
+  left: -1px;
 }
 #civitasks .ng-submitted .civihr-ui-select.ng-invalid, #cividocuments .ng-submitted .civihr-ui-select.ng-invalid,
 #civitasks .ng-submitted .civihr-ui-select.ng-invalid *,

--- a/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
+++ b/uk.co.compucorp.civicrm.tasksassignments/scss/civitasks/modules/_civihr-ui-select.scss
@@ -15,11 +15,6 @@
     font-size: 13px;
   }
 
-  .select2-search-choice-close {
-    background: none !important;
-    top: 3px !important;
-  }
-
   a.select2-search-choice-close { /* stylelint-disable-line selector-no-qualifying-type */
     top: 0 !important;
   }
@@ -29,10 +24,6 @@
       border: 1px solid $dropdown-border !important;
       border-bottom: 0 !important;
       padding-left: 12px !important;
-    }
-
-    .select2-arrow {
-      line-height: 31px;
     }
   }
 


### PR DESCRIPTION
## Overview
See https://github.com/compucorp/civihr/pull/2912. The T&A stylesheet too has some ad-hoc style for the select2 dropdown, and that too was the cause for the regression issues

## Screenshots comparison
_("before" is above, "after" is below)_
_(the before screenshots are taken with the fork synced but without the regression issues fixes)_

**Single select2, closed**
<img width="400" alt="ta-single-close-before" src="https://user-images.githubusercontent.com/6400898/47810338-5eedf300-dd43-11e8-8ea6-43f47577b098.png">
<img width="400" alt="ta-single-close-after" src="https://user-images.githubusercontent.com/6400898/47810336-5eedf300-dd43-11e8-91f0-e3e3d8032ea5.png">

The vertical alignment of both the "down" caret and the X icon is improved

**Single select2, open**
<img width="400" alt="ta-single-open-before" src="https://user-images.githubusercontent.com/6400898/47810340-5f868980-dd43-11e8-95c0-d8c0c93e432e.png">
<img width="400" alt="ta-single-open-after" src="https://user-images.githubusercontent.com/6400898/47810339-5f868980-dd43-11e8-851f-1bdb8b398b32.png">

The additional icon is removed, and the "up" caret is now of the same font size and with the same horizontal alignment of the "down" caret

**Multiple select2, closed**
<img width="400" alt="ta-multiple-closed-before" src="https://user-images.githubusercontent.com/6400898/47902758-ebeb9600-de82-11e8-9ddd-3e8fe3bacc08.png">
<img width="400" alt="ta-multiple-closed-after" src="https://user-images.githubusercontent.com/6400898/47902757-ebeb9600-de82-11e8-8b94-43974593be3d.png">

The vertical alignment of the text and the position of the icon is now fixed

**Multiple select2, open**
<img width="400" alt="ta-multiple-open-before" src="https://user-images.githubusercontent.com/6400898/47902760-ec842c80-de82-11e8-9d0e-04226aed906b.png">
<img width="400" alt="ta-multiple-open-after" src="https://user-images.githubusercontent.com/6400898/47902759-ec842c80-de82-11e8-93b1-fcb38b646f9c.png">

No major changes