### PR TITLE
PCHR-4243: Fix AngularJS 1.6 router links

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/DashboardSwitcher.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/DashboardSwitcher.php
@@ -2,7 +2,7 @@
 
 class CRM_Tasksassignments_DashboardSwitcher {
   public static function switchToTasksAndAssignments() {
-    $dashboardUrl = 'civicrm/tasksassignments/dashboard#/tasks';
+    $dashboardUrl = 'civicrm/tasksassignments/dashboard#!/tasks';
 
     CRM_Core_DAO::executeQuery("UPDATE civicrm_navigation SET url=%1 WHERE name='Home'", array(
       1 => array(

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/MyDocuments.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/MyDocuments.php
@@ -12,7 +12,7 @@ class CRM_Tasksassignments_Page_MyDocuments extends CRM_Core_Page {
       CRM_Utils_System::redirect('/dashboard#documents');
     }
     else {
-      CRM_Utils_System::redirect('/civicrm/tasksassignments/dashboard#/documents/my');
+      CRM_Utils_System::redirect('/civicrm/tasksassignments/dashboard#!/documents/my');
     }
   }
 }

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/MyTasks.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Page/MyTasks.php
@@ -13,7 +13,7 @@ class CRM_Tasksassignments_Page_MyTasks extends CRM_Core_Page
       CRM_Utils_System::redirect('/dashboard#tasks');
     }
     else {
-      CRM_Utils_System::redirect('/civicrm/tasksassignments/dashboard#/tasks/my');
+      CRM_Utils_System::redirect('/civicrm/tasksassignments/dashboard#!/tasks/my');
     }
 
     return FALSE;

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -316,8 +316,8 @@ class CRM_Tasksassignments_Reminder {
       $templateBodyHTML = CRM_Core_Smarty::singleton()->fetchWith('CRM/Tasksassignments/Reminder/DailyReminder.tpl', [
         'reminder' => $reminderData,
         'baseUrl' => CIVICRM_UF_BASEURL,
-        'myTasksUrl' => CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#/tasks/my',
-        'myDocumentsUrl' => CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#/documents/my',
+        'myTasksUrl' => CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#!/tasks/my',
+        'myDocumentsUrl' => CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#!/documents/my',
         'settings' => $settings,
       ]);
 
@@ -719,8 +719,8 @@ class CRM_Tasksassignments_Reminder {
     $taSettings = civicrm_api3('TASettings', 'get');
     $settings = $taSettings['values'];
     $notifications = self::getDocumentNotificationsData();
-    $myTasksUrl = CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#/tasks/my';
-    $myDocumentsUrl = CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#/documents/my';
+    $myTasksUrl = CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#!/tasks/my';
+    $myDocumentsUrl = CIVICRM_UF_BASEURL . '/civicrm/tasksassignments/dashboard#!/documents/my';
     foreach ($notifications as $assignee => $documentsSet) {
       list($assigneeId, $assigneeEmail) = explode(':', $assignee);
       $templateBodyHTML = CRM_Core_Smarty::singleton()->fetchWith('CRM/Tasksassignments/Reminder/DailyDocumentsNotification.tpl', array(

--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Upgrader.php
@@ -63,7 +63,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
       'domain_id'  => CRM_Core_Config::domainID(),
       'label'      => ts('Tasks and Assignments'),
       'name'       => 'tasksassignments',
-      'url'        => 'civicrm/tasksassignments/dashboard#/tasks',
+      'url'        => 'civicrm/tasksassignments/dashboard#!/tasks',
       'parent_id'  => NULL,
       'weight'     => $weight + 1,
       'permission' => 'access Tasks and Assignments',
@@ -239,7 +239,7 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
         array(
           'label' => ts('Dashboard'),
           'name' => 'ta_dashboard',
-          'url' => 'civicrm/tasksassignments/dashboard#/tasks',
+          'url' => 'civicrm/tasksassignments/dashboard#!/tasks',
         ),
         array(
           'label' => ts('Settings'),
@@ -516,22 +516,22 @@ class CRM_Tasksassignments_Upgrader extends CRM_Tasksassignments_Upgrader_Base {
       [
         'label' => ts('Tasks'),
         'name' => 'ta_dashboard_tasks',
-        'url' => 'civicrm/tasksassignments/dashboard#/tasks',
+        'url' => 'civicrm/tasksassignments/dashboard#!/tasks',
       ],
       [
         'label' => ts('Documents'),
         'name' => 'ta_dashboard_documents',
-        'url' => 'civicrm/tasksassignments/dashboard#/documents',
+        'url' => 'civicrm/tasksassignments/dashboard#!/documents',
       ],
       [
         'label' => ts('Calendar'),
         'name' => 'ta_dashboard_calendar',
-        'url' => 'civicrm/tasksassignments/dashboard#/calendar',
+        'url' => 'civicrm/tasksassignments/dashboard#!/calendar',
       ],
       [
         'label' => ts('Key Dates'),
         'name' => 'ta_dashboard_keydates',
-        'url' => 'civicrm/tasksassignments/dashboard#/key-dates',
+        'url' => 'civicrm/tasksassignments/dashboard#!/key-dates',
       ]
     ];
 

--- a/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TASettingsTest.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/tests/phpunit/api/v3/TASettingsTest.php
@@ -95,7 +95,7 @@ class api_v3_TASettingsTest extends BaseHeadlessTest {
       ]
     ]);
 
-    $this->assertEquals('civicrm/tasksassignments/dashboard#/tasks', $this->getHomeNavigationUrl());
+    $this->assertEquals('civicrm/tasksassignments/dashboard#!/tasks', $this->getHomeNavigationUrl());
   }
 
   public function testSetUpdatesDashboardUrlToDefaultCiviDashboardWhenIsTaskDashboardIsNot1() {


### PR DESCRIPTION
## Overview

This PR fixes all links in T&A that include AngularJS routing parameters. Links broke due to upgrade of AngularJS to version `1.7` (see https://github.com/compucorp/civihr/pull/2790).

This PR also has a child PR here https://github.com/compucorp/civihr/pull/2953.

## Before

![1](https://user-images.githubusercontent.com/3973243/48856864-6f781300-edaf-11e8-858a-765e78ee3394.gif)

## After

![2](https://user-images.githubusercontent.com/3973243/48856833-5e2f0680-edaf-11e8-8838-fac58df5b9f6.gif)

## Technical Details

We simply replace all the occurrences of `[^/]#/` to `$1#!/` (basically adding an `!` after the hash symbol as per AngularJS 1.6+.

Please note, we do **not** replace all the occurrences or `#/` because some of them is CiviCRM, for example: `civicrm/a/#/caseType`.

-----

✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
⏹PHP Unit Tests - not needed