### PR TITLE
PCHR-4363: Fix tasks and documents email notifications buttons URLs

### DIFF
--- a/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
+++ b/uk.co.compucorp.civicrm.tasksassignments/CRM/Tasksassignments/Reminder.php
@@ -224,6 +224,11 @@ class CRM_Tasksassignments_Reminder {
       }
 
       $isAssignee = array_search($contactId, $activityContacts['assignees']['ids']) !== FALSE;
+      $activityUrl = $isAssignee
+        ? '/tasks-and-documents'
+        : '/civicrm/activity/view?action=view&reset=1&id=' .
+          $activityId .
+          '&cid=&context=activity&searchContext=activity';
       $tasksButtonUrl = $isAssignee
         ? '/tasks-and-documents'
         : '/civicrm/tasksassignments/dashboard#!/tasks/all';
@@ -241,7 +246,7 @@ class CRM_Tasksassignments_Reminder {
         'isReminder' => $isReminder,
         'isDelete' => $isDelete,
         'notes' => $notes,
-        'activityUrl' => CIVICRM_UF_BASEURL . '/civicrm/activity/view?action=view&reset=1&id=' . $activityId . '&cid=&context=activity&searchContext=activity',
+        'activityUrl' => CIVICRM_UF_BASEURL . $activityUrl,
         'activityName' => $activityName,
         'activityType' => self::$_activityOptions['type'][$activityResult['activity_type_id']],
         'activityTargets' => implode(', ', $activityContacts['targets']['links']),

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Footer.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Footer.tpl
@@ -6,8 +6,8 @@
                                       <table class="mbutton" width="94%" cellspacing="0" cellpadding="0" style="border:1px solid #35a4bf;">
                                         <tr style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
                                           <td align="center" style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
-                                            <a href="{$myTasksUrl}" style="color:#42b0cb;font-weight:normal;text-decoration: none;font-size:14px;font-weight:bold;font-family:Helvetica, Arial, sans-serif;text-decoration:none;line-height:40px;width:100%;display:inline-block;">
-                                              <span style="color:#ffffff;">See my tasks</span>
+                                            <a href="{$tasksButtonUrl}" style="color:#42b0cb;font-weight:normal;text-decoration: none;font-size:14px;font-weight:bold;font-family:Helvetica, Arial, sans-serif;text-decoration:none;line-height:40px;width:100%;display:inline-block;">
+                                              <span style="color:#ffffff;">{$tasksButtonLabel}</span>
                                             </a>
                                           </td>
                                         </tr>
@@ -17,8 +17,8 @@
                                       <table class="mbutton" width="94%" cellspacing="0" cellpadding="0" style="border:1px solid #35a4bf;">
                                         <tr style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
                                           <td align="center" style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
-                                            <a href="{$myDocumentsUrl}" style="color:#42b0cb;font-weight:normal;text-decoration: none;font-size:14px;font-weight:bold;font-family:Helvetica, Arial, sans-serif;text-decoration:none;line-height:40px;width:100%;display:inline-block;">
-                                              <span style="color:#ffffff;">See my documents</span>
+                                            <a href="{$documentsButtonUrl}" style="color:#42b0cb;font-weight:normal;text-decoration: none;font-size:14px;font-weight:bold;font-family:Helvetica, Arial, sans-serif;text-decoration:none;line-height:40px;width:100%;display:inline-block;">
+                                              <span style="color:#ffffff;">{$documentsButtonLabel}</span>
                                             </a>
                                           </td>
                                         </tr>

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Footer.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Footer.tpl
@@ -1,44 +1,48 @@
-                                                            {if $isDelete === false}
-                                                                <br/>
-                                                                <table class="mtable" width="100%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-                                                                    <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-                                                                        <td width="50%" align="left" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-                                                                            <table class="mbutton" width="94%" cellspacing="0" cellpadding="0" style="border:1px solid #35a4bf;">
-                                                                                <tr style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;"> 
-                                                                                    <td align="center" style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
-                                                                                        <a href="{$myTasksUrl}" style="color:#42b0cb;font-weight:normal;text-decoration: none;font-size:14px;font-weight:bold;font-family:Helvetica, Arial, sans-serif;text-decoration:none;line-height:40px;width:100%;display:inline-block;"><span style="color:#ffffff;">See my tasks</span></a>
-                                                                                    </td>
-                                                                                </tr>
-                                                                            </table>
-                                                                        </td>
-                                                                        <td width="50%" align="right" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-                                                                            <table class="mbutton" width="94%" cellspacing="0" cellpadding="0" style="border:1px solid #35a4bf;">
-                                                                                <tr style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;"> 
-                                                                                    <td align="center" style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
-                                                                                        <a href="{$myDocumentsUrl}" style="color:#42b0cb;font-weight:normal;text-decoration: none;font-size:14px;font-weight:bold;font-family:Helvetica, Arial, sans-serif;text-decoration:none;line-height:40px;width:100%;display:inline-block;"><span style="color:#ffffff;">See my documents</span></a>
-                                                                                    </td>
-                                                                                </tr>
-                                                                            </table>
-                                                                        </td>
-                                                                    </tr>
-                                                                </table>
-                                                            {/if}
-                                                            </div>
-                                                        </td>
-                                                    </tr>
-                                                </table>
-                                                <!-- // End Module: Standard Content \\ -->
-                                            </td>
+                              {if $isDelete === false}
+                                <br/>
+                                <table class="mtable" width="100%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+                                  <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+                                    <td width="50%" align="left" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+                                      <table class="mbutton" width="94%" cellspacing="0" cellpadding="0" style="border:1px solid #35a4bf;">
+                                        <tr style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
+                                          <td align="center" style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
+                                            <a href="{$myTasksUrl}" style="color:#42b0cb;font-weight:normal;text-decoration: none;font-size:14px;font-weight:bold;font-family:Helvetica, Arial, sans-serif;text-decoration:none;line-height:40px;width:100%;display:inline-block;">
+                                              <span style="color:#ffffff;">See my tasks</span>
+                                            </a>
+                                          </td>
                                         </tr>
-                                    </table>
-                                    <!-- // End Template Body \\ -->
-                                </td>
-                            </tr>
+                                      </table>
+                                    </td>
+                                    <td width="50%" align="right" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+                                      <table class="mbutton" width="94%" cellspacing="0" cellpadding="0" style="border:1px solid #35a4bf;">
+                                        <tr style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
+                                          <td align="center" style="width:100%;height:40px;color:#ffffff;display:block;background-color:#42b0cb;">
+                                            <a href="{$myDocumentsUrl}" style="color:#42b0cb;font-weight:normal;text-decoration: none;font-size:14px;font-weight:bold;font-family:Helvetica, Arial, sans-serif;text-decoration:none;line-height:40px;width:100%;display:inline-block;">
+                                              <span style="color:#ffffff;">See my documents</span>
+                                            </a>
+                                          </td>
+                                        </tr>
+                                      </table>
+                                    </td>
+                                  </tr>
+                                </table>
+                              {/if}
+                              </div>
+                            </td>
+                          </tr>
                         </table>
-                        <br>
-                    </td>
-                </tr>
+                        <!-- // End Module: Standard Content \\ -->
+                      </td>
+                    </tr>
+                  </table>
+                  <!-- // End Template Body \\ -->
+                </td>
+              </tr>
             </table>
-        </center>
-    </body>
+            <br>
+          </td>
+        </tr>
+      </table>
+    </center>
+  </body>
 </html>

--- a/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Reminder.tpl
+++ b/uk.co.compucorp.civicrm.tasksassignments/templates/CRM/Tasksassignments/Reminder/Reminder.tpl
@@ -1,67 +1,72 @@
 {include file='CRM/Tasksassignments/Reminder/Header.tpl'}
-<span class="h4" style="color:#202020;display:block;font-family:Arial;font-size:22px;font-weight:normal;line-height:100%;margin-bottom:10px;text-align:left;">{if $isReminder}Reminder: {/if}<a class="mlink" style="color:#42b0cb;font-weight:normal;text-decoration:underline;" href="{$activityUrl}">{$activityName}</a></span>
+<span class="h4" style="color:#202020;display:block;font-family:Arial;font-size:22px;font-weight:normal;line-height:100%;margin-bottom:10px;text-align:left;">
+  {if $isReminder}Reminder: {/if}
+  <a class="mlink" style="color:#42b0cb;font-weight:normal;text-decoration:underline;" href="{$activityUrl}">
+    {$activityName}
+  </a>
+</span>
 {if $notes}
-<table class="mtable notes" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;margin-top:8px;" width="100%">
+  <table class="mtable notes" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;margin-top:8px;" width="100%">
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Notes:</td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$notes}</td>
+      <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Notes:</td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$notes}</td>
     </tr>
-</table>
+  </table>
 {/if}
 <hr style="height:0px;border:0px none;border-bottom:1px solid;border-color:#e0e0e0;margin:16px 0 10px;"/>
 <table class="mtable" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;" width="100%">
-{if $activityTargets}
+  {if $activityTargets}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Contact:</td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityTargets}</td>
+      <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Contact:</td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityTargets}</td>
     </tr>
-{/if}
-{if $activityAssignee}
+  {/if}
+  {if $activityAssignee}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-            {if $previousAssignee}
-                New Assignee:
-            {else}
-                Assignee:
-            {/if}
-        </td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityAssignee}</td>
+      <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
+        {if $previousAssignee}
+          New Assignee:
+        {else}
+          Assignee:
+        {/if}
+      </td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityAssignee}</td>
     </tr>
-{/if}
-{if $previousAssignee}
+  {/if}
+  {if $previousAssignee}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="25%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Original Assignee:</td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$previousAssignee}</td>
+      <td width="25%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Original Assignee:</td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$previousAssignee}</td>
     </tr>
-{/if}
-{if $activityType}
+  {/if}
+  {if $activityType}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Task:</td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityType}</td>
+      <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Task:</td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityType}</td>
     </tr>
-{/if}
+  {/if}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Status:</td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityStatus}</td>
+      <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Status:</td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityStatus}</td>
     </tr>
-{if $activityDue}
+  {if $activityDue}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Due:</td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityDue}</td>
+      <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Due:</td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityDue}</td>
     </tr>
-{/if}
-{if $activitySubject}
+  {/if}
+  {if $activitySubject}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Subject:</td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activitySubject|strip_tags}</td>
+      <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Subject:</td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activitySubject|strip_tags}</td>
     </tr>
-{/if}
-{if $activityDetails}
+  {/if}
+  {if $activityDetails}
     <tr style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">
-        <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Details:</td>
-        <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityDetails}</td>
+      <td width="15%" style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">Details:</td>
+      <td style="margin: 0px;padding: 0px;border: 0;vertical-align: top;">{$activityDetails}</td>
     </tr>
-{/if}
+  {/if}
 </table>
 <hr style="height:0px;border:0px none;border-bottom:1px solid;border-color:#e0e0e0;margin:16px 0 10px;"/>
 {include file='CRM/Tasksassignments/Reminder/Footer.tpl'}


### PR DESCRIPTION
## Overview

This PR fixes URLs and augments labels for buttons in the T&A email notifications.

## Before

The links are broken, the button label for admin is wrong (should be "See all...") and the link for the staff (assignee) does not make any sense, they would probably not have access to `/civicrm...` at all (unless the assignee is admin).

Please note the URLs in the left bottom corner.

![1](https://user-images.githubusercontent.com/3973243/50283998-857d0000-044f-11e9-828e-129c9fabb697.gif)

## After

The labels and URLs are now fixed. Please note the URLs in the left bottom corner.

![2](https://user-images.githubusercontent.com/3973243/50284002-89a91d80-044f-11e9-8ed8-a73994f68ed2.gif)

Also, the email header link URL has been fixed for Assignees (it was earlier leading to `/civicrm...`). We left the URL as is for the Creators.

![image](https://user-images.githubusercontent.com/3973243/51323113-28309a80-1a5f-11e9-828d-1aed19125048.png)

## Technical Details

We define if an email is sent to assignee or not:

```php
$isAssignee = array_search($contactId, $activityContacts['assignees']['ids']) !== FALSE;
```

Then, based on the flag above, we define URLs and labels:

```php
$tasksButtonUrl = $isAssignee
  ? '/tasks-and-documents'
  : '/civicrm/tasksassignments/dashboard#!/tasks/all';
$tasksButtonLabel = $isAssignee
  ? ts('See my tasks')
  : ts('See all tasks');
$documentsButtonUrl = $isAssignee
  ? '/tasks-and-documents'
  : '/civicrm/tasksassignments/dashboard#!/documents/all';
$documentsButtonLabel = $isAssignee
  ? ts('See my documents')
  : ts('See all documents');
```

Then, we pass these variables to the template:

```html
<a href="{$tasksButtonUrl}" ...>
  <span ...>{$tasksButtonLabel}</span>
</a>
<!-- and the same for documents button -->
```

We also fix the email header URL for Assignees:

```php
$activityUrl = $isAssignee
  ? '/tasks-and-documents'
  : '/civicrm/activity/view?action=view&reset=1&id=' .
    $activityId .
    '&cid=&context=activity&searchContext=activity';

...

$templateBodyHTML = ...
  ...
  'activityUrl' => CIVICRM_UF_BASEURL . $activityUrl,
  ...
```

## Comments
⚠️A regression has been detected for Daily Reminders (out of scope of this ticket). 3 years ago a PR was merged https://github.com/compucorp/civihr-tasks-assignments/pull/17/files#diff-7145990a7ff076d1f0d966d0db9a0cffR1 and it introduced a regression causing a footer with buttons never appear for Daily Reminder emails:

```html
{if $isDelete === false}
  ... buttons
{/if}
```
This was made in order to not show buttons if you receive a notification about a deleted task or document. However, this template is also used for Daily Reminder emails. The `isDelete` flag has never been passed for Daily Reminders, thus, the block with buttons would never been shown.

The URLs for buttons were removed for Daily Reminders as this data is now redundant, but a `TODO` note was left.

---- 

✅Manual Tests - passed
⏹Jasmine Tests - not needed
⏹JS distributive files - not needed
⏹CSS distributive files - not needed
⏹Backstop tests - not needed
⏹PHP Unit Tests - NOT AVAILABLE FOR THIS FILE
